### PR TITLE
fix: lowercase Docker image tags to fix GHCR push

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,6 +23,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -37,8 +39,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
 
   dispatch:
     needs: build


### PR DESCRIPTION
## Summary

- Lowercase the Docker image name using bash parameter expansion (`${GITHUB_REPOSITORY,,}`) to fix OCI tag validation

The org name `f5xc-SalesDemos` contains uppercase letters, but Docker/OCI registries require lowercase repository names. The `docker/build-push-action` was using `${{ github.repository }}` directly which preserved the mixed case.

## Test plan

- [ ] Verify `build-image.yml` workflow passes after merge
- [ ] Confirm image is pushed to `ghcr.io/f5xc-salesdemos/docs-builder:latest`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)