### PR TITLE
fix: lowercase org name to f5xc-salesdemos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       prefix: "chore(deps):"
     labels:
       - "dependencies"
-    # TODO: Replace with f5xc-SalesDemos team handle when available
+    # TODO: Replace with f5xc-salesdemos team handle when available
     assignees:
       - "robinmordasiewicz"
     open-pull-requests-limit: 10
@@ -31,7 +31,7 @@ updates:
       prefix: "chore(deps):"
     labels:
       - "dependencies"
-    # TODO: Replace with f5xc-SalesDemos team handle when available
+    # TODO: Replace with f5xc-salesdemos team handle when available
     assignees:
       - "robinmordasiewicz"
     open-pull-requests-limit: 10

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   auto-merge:
-    # TODO: Update to f5xc-SalesDemos/docs-control when template repo is migrated (Phase 3)
+    # TODO: Update to f5xc-salesdemos/docs-control when template repo is migrated (Phase 3)
     uses: robinmordasiewicz/f5xc-template/.github/workflows/auto-merge.yml@main
     secrets:
       REPO_ADMIN_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
         run: |
-          # TODO: Update to f5xc-SalesDemos/docs-control when template repo is migrated (Phase 3)
+          # TODO: Update to f5xc-salesdemos/docs-control when template repo is migrated (Phase 3)
           repos=$(gh api repos/robinmordasiewicz/f5xc-template/contents/.github/config/downstream-repos.json --jq '.content' | base64 -d | jq -r '.[]')
           if [ -z "$repos" ]; then
             echo "::error::Failed to fetch downstream repo list"

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   enforce:
-    # TODO: Update to f5xc-SalesDemos/docs-control when template repo is migrated (Phase 3)
+    # TODO: Update to f5xc-salesdemos/docs-control when template repo is migrated (Phase 3)
     uses: robinmordasiewicz/f5xc-template/.github/workflows/enforce-repo-settings.yml@main
     secrets:
       repo-admin-token: ${{ secrets.REPO_ADMIN_TOKEN }}

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   docs:
-    # TODO: Update to f5xc-SalesDemos/docs-control when template repo is migrated (Phase 3)
+    # TODO: Update to f5xc-salesdemos/docs-control when template repo is migrated (Phase 3)
     uses: robinmordasiewicz/f5xc-template/.github/workflows/github-pages-deploy.yml@main

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -212,7 +212,7 @@ docker run --rm \
 ### Option 2: Manual builder checkout
 
 ```bash
-git clone https://github.com/f5xc-SalesDemos/docs-builder.git /tmp/builder
+git clone https://github.com/f5xc-salesdemos/docs-builder.git /tmp/builder
 cd /tmp/builder
 npm ci
 rm -rf src/content/docs/*

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -1,7 +1,7 @@
 # Org Migration Guide
 
 This document tracks the migration of the docs pipeline from the
-`robinmordasiewicz` GitHub org to the `f5xc-SalesDemos` org.
+`robinmordasiewicz` GitHub org to the `f5xc-salesdemos` org.
 
 ## Migration Phases
 
@@ -10,7 +10,7 @@ This document tracks the migration of the docs pipeline from the
 **Status:** Complete
 
 Migrated `robinmordasiewicz/f5xc-docs-builder` to
-`f5xc-SalesDemos/docs-builder`.
+`f5xc-salesdemos/docs-builder`.
 
 Changes made:
 
@@ -39,11 +39,11 @@ What still references the old org (and why):
 ### Phase 2: docs-theme (future)
 
 Migrate `robinmordasiewicz/f5xc-docs-theme` to
-`f5xc-SalesDemos/docs-theme`.
+`f5xc-salesdemos/docs-theme`.
 
 Checklist:
 
-- [ ] Create `f5xc-SalesDemos/docs-theme` repo
+- [ ] Create `f5xc-salesdemos/docs-theme` repo
 - [ ] Re-publish npm package under `@f5xc-salesdemos` scope
 - [ ] Update `package.json` alias in this repo
 - [ ] Update `docs/01-architecture.mdx` npm alias example
@@ -52,11 +52,11 @@ Checklist:
 ### Phase 3: docs-control (future)
 
 Migrate `robinmordasiewicz/f5xc-template` to
-`f5xc-SalesDemos/docs-control`.
+`f5xc-salesdemos/docs-control`.
 
 Checklist:
 
-- [ ] Create `f5xc-SalesDemos/docs-control` repo
+- [ ] Create `f5xc-salesdemos/docs-control` repo
 - [ ] Update all workflow `uses:` references (4 workflow files)
 - [ ] Update `build-image.yml` dispatch API call
 - [ ] Update `docs/05-ci-cd.mdx` code snippets

--- a/docs/05-ci-cd.mdx
+++ b/docs/05-ci-cd.mdx
@@ -131,7 +131,7 @@ Runs every 6 hours and on changes to the settings config file. Applies branch pr
 
 ### Centralized Template
 
-The `robinmordasiewicz/f5xc-template` repository is the single source of truth for (this will become `f5xc-SalesDemos/docs-control` in a future migration phase):
+The `robinmordasiewicz/f5xc-template` repository is the single source of truth for (this will become `f5xc-salesdemos/docs-control` in a future migration phase):
 
 - Reusable workflow definitions (docs deploy, repo settings enforcement)
 - Managed files synced across all repos in the organization

--- a/docs/06-content-authors.mdx
+++ b/docs/06-content-authors.mdx
@@ -79,11 +79,11 @@ For a full production build that matches CI output, pass `GITHUB_REPOSITORY` so 
 docker run --rm \
   -v "$(pwd)/docs:/content/docs:ro" \
   -v "$(pwd)/output:/output" \
-  -e GITHUB_REPOSITORY="f5xc-SalesDemos/my-docs" \
+  -e GITHUB_REPOSITORY="f5xc-salesdemos/my-docs" \
   ghcr.io/f5xc-salesdemos/docs-builder:latest
 ```
 
-Replace `f5xc-SalesDemos/my-docs` with your actual `owner/repo`. This sets `DOCS_BASE` to `/my-docs`, matching how GitHub Pages serves project sites under a subpath.
+Replace `f5xc-salesdemos/my-docs` with your actual `owner/repo`. This sets `DOCS_BASE` to `/my-docs`, matching how GitHub Pages serves project sites under a subpath.
 
 Then serve the output with the correct base path:
 
@@ -108,7 +108,7 @@ docker run --rm \
   -v "$(pwd)/docs:/content/docs:ro" \
   -v "$(pwd)/docs/images:/app/public/images:ro" \
   -v "$(pwd)/output:/output" \
-  -e GITHUB_REPOSITORY="f5xc-SalesDemos/my-docs" \
+  -e GITHUB_REPOSITORY="f5xc-salesdemos/my-docs" \
   ghcr.io/f5xc-salesdemos/docs-builder:latest
 ```
 
@@ -140,7 +140,7 @@ Pass them with `-e`:
 ```sh
 docker run --rm -it \
   -e DOCS_TITLE="My Local Preview" \
-  -e GITHUB_REPOSITORY="f5xc-SalesDemos/my-docs" \
+  -e GITHUB_REPOSITORY="f5xc-salesdemos/my-docs" \
   -v "$(pwd)/docs:/content/docs" \
   -p 4321:4321 \
   --entrypoint sh \


### PR DESCRIPTION
## Summary

- Replace all mixed-case `f5xc-SalesDemos` references with lowercase `f5xc-salesdemos` across 9 files

The GitHub org is being renamed to all-lowercase `f5xc-salesdemos`. This updates docs, workflow TODO comments, dependabot config, and migration tracking files.

## Test plan

- [ ] `grep -ri "f5xc-SalesDemos"` returns no results
- [ ] CI checks pass

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)