### PR TITLE
fix: remove cross-repo dispatch, add workflow_run trigger

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,28 +40,3 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
-
-  dispatch:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch github-pages-deploy workflows
-        env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
-        run: |
-          repos=$(gh api repos/f5xc-salesdemos/docs-control/contents/.github/config/downstream-repos.json --jq '.content' | base64 -d | jq -r '.[]')
-          if [ -z "$repos" ]; then
-            echo "::error::Failed to fetch downstream repo list"
-            exit 1
-          fi
-          failed=0
-          for repo in $repos; do
-            echo "Dispatching github-pages-deploy.yml to ${repo}"
-            if ! gh workflow run github-pages-deploy.yml --repo "${repo}"; then
-              echo "::warning::Failed to dispatch to ${repo}"
-              failed=$((failed + 1))
-            fi
-          done
-          if [ "$failed" -gt 0 ]; then
-            echo "::warning::${failed} dispatch(es) failed"
-          fi

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+  workflow_run:
+    workflows: ["Build and Publish Docker Image"]
+    branches: [main]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -18,4 +22,7 @@ concurrency:
 
 jobs:
   docs:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     uses: f5xc-salesdemos/docs-control/.github/workflows/github-pages-deploy.yml@main


### PR DESCRIPTION
## Summary
- Removed the `dispatch` job from `build-image.yml` that required a `REPO_ADMIN_TOKEN` PAT to trigger downstream repos
- Added a `workflow_run` trigger to `github-pages-deploy.yml` so Pages auto-rebuilds after a successful Docker image build
- Added `if` condition to skip Pages deploy when the Docker build fails

This switches to a pull-based rebuild model where each repo handles its own triggers, eliminating all cross-repo token requirements.

Closes #18

## Test plan
- [ ] Merge and verify `build-image.yml` no longer has a `dispatch` job
- [ ] Trigger a Docker image build and confirm `workflow_run` auto-triggers Pages deploy
- [ ] Verify Pages site remains live after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)