### PR TITLE
fix: remove dead dispatch job from build-image.yml

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,28 +40,3 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
-
-  dispatch:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch github-pages-deploy workflows
-        env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
-        run: |
-          repos=$(gh api repos/f5xc-salesdemos/docs-control/contents/.github/config/downstream-repos.json --jq '.content' | base64 -d | jq -r '.[]')
-          if [ -z "$repos" ]; then
-            echo "::error::Failed to fetch downstream repo list"
-            exit 1
-          fi
-          failed=0
-          for repo in $repos; do
-            echo "Dispatching github-pages-deploy.yml to ${repo}"
-            if ! gh workflow run github-pages-deploy.yml --repo "${repo}"; then
-              echo "::warning::Failed to dispatch to ${repo}"
-              failed=$((failed + 1))
-            fi
-          done
-          if [ "$failed" -gt 0 ]; then
-            echo "::warning::${failed} dispatch(es) failed"
-          fi


### PR DESCRIPTION
## Summary
- Remove the `dispatch` job from `build-image.yml` that requires unconfigured `REPO_ADMIN_TOKEN`
- The `build` job succeeds but `dispatch` fails every run, marking the entire workflow as failed
- Cross-repo dispatch was superseded by the pull-based rebuild architecture (docs-control#3)

Closes #26

## Test plan
- [ ] After merge, trigger a Docker image build (or wait for daily schedule)
- [ ] Confirm the workflow completes with success (no more dispatch failure)
- [ ] Verify `ghcr.io/f5xc-salesdemos/docs-builder:latest` is still pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)