### PR TITLE
fix: update f5xc-docs-theme dependency to current version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "f5xc-docs-theme": "^1.29.0",
+    "f5xc-docs-theme": "^1.2.0",
     "@astrojs/react": "^4.4.2",
     "@scalar/api-reference-react": "^0.8.55",
     "@astrojs/starlight": "^0.37.6",


### PR DESCRIPTION
## Summary
- Update `f5xc-docs-theme` dependency from `^1.29.0` (old org) to `^1.2.0` (current)

## Problem
After moving from `robinmordasiewicz` to `f5xc-salesdemos`, the theme package versioning was reset. The old `^1.29.0` range causes `npm ci` to install the stale package from the previous org, which contains the wrong avatar and potentially stale theme code.

## Test plan
- [ ] CI passes
- [ ] After merge, Docker image rebuild picks up `f5xc-docs-theme@1.2.0`
- [ ] Re-trigger Pages deploy for docs-theme — avatar should show `f5xc-salesdemos` org logo

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)