### PR TITLE
feat: dispatch Pages rebuilds to docs-sites after image build

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -1,0 +1,39 @@
+name: Dispatch Downstream Pages Rebuilds
+
+on:
+  workflow_run:
+    workflows: ["Build and Publish Docker Image"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dispatch-downstream
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Trigger Pages rebuilds
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Dispatch to docs-sites repos
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          CONFIG_REPO="f5xc-salesdemos/docs-control"
+          CONFIG_PATH=".github/config/docs-sites.json"
+
+          echo "Fetching docs-sites.json from ${CONFIG_REPO}..."
+          SITES=$(gh api "repos/${CONFIG_REPO}/contents/${CONFIG_PATH}" --jq '.content' | base64 -d)
+
+          echo "$SITES" | jq -r '.[].url' | while read -r url; do
+            repo=$(echo "$url" | sed 's|https://\([^.]*\)\.github\.io/\([^/]*\)/.*|\1/\2|')
+            echo "Dispatching github-pages-deploy.yml to ${repo}..."
+            if gh workflow run github-pages-deploy.yml --repo "$repo"; then
+              echo "  [OK] ${repo}"
+            else
+              echo "  [FAIL] ${repo} (workflow may not exist yet)"
+            fi
+          done


### PR DESCRIPTION
## Summary
- Add `dispatch-downstream.yml` workflow triggered on successful `Build and Publish Docker Image` completion
- Reads `docs-sites.json` from `f5xc-salesdemos/docs-control` to get the list of target repos
- Dispatches `github-pages-deploy.yml` via `workflow_dispatch` to each repo so content sites rebuild with the updated Docker image
- Uses `RELEASE_TOKEN` secret — needs to be added to this repo with `actions: write` on all target repos

## Test plan
- [ ] Add `RELEASE_TOKEN` secret to docs-builder repo
- [ ] Trigger a Docker image build (push or dispatch)
- [ ] Confirm `Dispatch Downstream Pages Rebuilds` runs after image build succeeds
- [ ] Confirm `github-pages-deploy.yml` triggers on each repo listed in docs-sites.json

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)