### PR TITLE
fix: bake all dependencies into Docker image at build time

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,10 @@ RUN npm ci --legacy-peer-deps
 # Copy framework code
 COPY . .
 
+# Bake theme config into the image (single source of truth)
+RUN cp node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs && \
+    cp node_modules/f5xc-docs-theme/src/content.config.ts /app/src/content.config.ts
+
 # Remove placeholder content
 RUN rm -rf src/content/docs/*
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,14 +5,6 @@ CONTENT_DIR="${CONTENT_DIR:-/content/docs}"
 OUTPUT_DIR="${OUTPUT_DIR:-/output}"
 GENERATE_PDF="${GENERATE_PDF:-false}"
 
-# Update dependencies to latest versions
-npm install --legacy-peer-deps
-npm update --legacy-peer-deps
-
-# Copy Astro config from theme package (single source of truth)
-cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
-cp /app/node_modules/f5xc-docs-theme/src/content.config.ts /app/src/content.config.ts
-
 # Inject content
 if [ -d "$CONTENT_DIR" ]; then
   cp -r "$CONTENT_DIR"/* /app/src/content/docs/


### PR DESCRIPTION
## Summary
- Move theme config file copying (`astro.config.mjs`, `content.config.ts`) from runtime entrypoint to Dockerfile `RUN` step
- Remove `npm install` and `npm update` from entrypoint — deps are already installed by `npm ci` during image build
- Eliminates internet access requirement at container startup, enabling DMZ deployments

Closes #40

## Test plan
- [ ] Docker image build workflow succeeds
- [ ] Downstream Pages deploys still work with the new image
- [ ] Local preview with `docker run` works without network access at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)