### PR TITLE
feat: build multi-arch Docker image for amd64 and arm64

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -31,6 +31,7 @@ jobs:
         run: npm install f5xc-docs-theme@latest --legacy-peer-deps
       - name: Lowercase image name
         run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -42,7 +43,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}


### PR DESCRIPTION
## Summary
- Add `docker/setup-qemu-action@v3` for cross-architecture emulation during CI
- Add `linux/arm64` to build platforms alongside `linux/amd64`
- ARM-based Mac developers get a native image instead of running under Rosetta

Closes #44

## Test plan
- [ ] Docker image build workflow succeeds for both platforms
- [ ] `docker pull ghcr.io/f5xc-salesdemos/docs-builder:latest` works without `--platform` on ARM Mac
- [ ] Full build test passes on ARM Mac natively
- [ ] Downstream Pages deploys still work (amd64 runners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)