### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -14,14 +14,4 @@ concurrency:
 
 jobs:
   check-linked-issue:
-    runs-on: ubuntu-latest
-    name: Check linked issues
-    steps:
-      - uses: nearform-actions/github-action-check-linked-issues@v1
-        with:
-          exclude-branches: "dependabot/**,release/**,openapi-sync/**,plugin-sync/**,deps/**,sync/**,docs/update-*"
-          custom-message: >-
-            This PR must be linked to a GitHub issue. Use 'Closes #123'
-            in the PR description, or link an issue from the sidebar.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: f5xc-salesdemos/docs-control/.github/workflows/require-linked-issue.yml@main


### PR DESCRIPTION
Closes #46

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/require-linked-issue.yml