### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -14,5 +14,5 @@ concurrency:
 
 jobs:
   check:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/reusable-require-linked-issue.yml@main
+    uses: f5xc-salesdemos/docs-control/.github/workflows/require-linked-issue.yml@main
     secrets: inherit


### PR DESCRIPTION
Closes #61

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/require-linked-issue.yml