### PR TITLE
docs: update stale pre-migration repo name references

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
-      - name: Resolve latest f5xc-docs-theme
+      - name: Resolve latest docs-theme
         run: npm install f5xc-docs-theme@latest --legacy-peer-deps
       - name: Lowercase image name
         run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:24-alpine AS builder
-LABEL org.opencontainers.image.description="f5xc-docs-builder"
+LABEL org.opencontainers.image.description="docs-builder"
 WORKDIR /app
 
 # Install Chromium and dependencies for Puppeteer (PDF generation)

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -19,7 +19,7 @@ content-repo/
     index.mdx
     guide.mdx
 
-f5xc-docs-builder/
+docs-builder/
   src/content/docs/ ← empty at rest (.gitkeep)
 ```
 
@@ -102,7 +102,7 @@ flowchart LR
 | Concern | When | How |
 |---------|------|-----|
 | MDX → HTML | Build time | Astro compiler |
-| Mermaid code blocks → container divs | Build time | `remark-mermaid.mjs` plugin (from `f5xc-docs-theme`) |
+| Mermaid code blocks → container divs | Build time | `remark-mermaid.mjs` plugin (from `docs-theme`) |
 | Placeholder tokens → interactive spans | Client time | `placeholder-dom.ts` TreeWalker |
 | Mermaid SVG rendering | Client time | `mermaid` CDN import in `placeholder-dom.ts` |
 | Placeholder form state | Client time | `placeholder-store.ts` + localStorage |

--- a/docs/content-authors.mdx
+++ b/docs/content-authors.mdx
@@ -13,8 +13,8 @@ Three repos collaborate to produce the final site:
 
 | Repo | Artifact | Role |
 |------|----------|------|
-| **f5xc-docs-theme** | npm package | Astro/Starlight config, CSS, logos, plugins |
-| **f5xc-docs-builder** | Docker image | Pulls the theme at runtime, compiles MDX to static HTML |
+| **docs-theme** | npm package | Astro/Starlight config, CSS, logos, plugins |
+| **docs-builder** | Docker image | Pulls the theme at runtime, compiles MDX to static HTML |
 | **docs-control** | Reusable GitHub workflow | Orchestrates the container in CI, deploys to GitHub Pages |
 
 Content repos only depend on the Docker image — everything else is handled automatically.

--- a/docs/mermaid.mdx
+++ b/docs/mermaid.mdx
@@ -9,7 +9,7 @@ The builder supports [Mermaid](https://mermaid.js.org/) diagrams with two-phase 
 
 ## Remark Plugin
 
-The remark-mermaid plugin (provided by the `f5xc-docs-theme` npm package) runs during the Astro build. It uses `unist-util-visit` to find fenced code blocks with `lang === 'mermaid'` and replaces them with HTML:
+The remark-mermaid plugin (provided by the `docs-theme` npm package) runs during the Astro build. It uses `unist-util-visit` to find fenced code blocks with `lang === 'mermaid'` and replaces them with HTML:
 
 ```js
 visit(tree, 'code', (node, index, parent) => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "f5xc-docs-builder",
+  "name": "docs-builder",
   "type": "module",
   "version": "1.0.0",
   "scripts": {


### PR DESCRIPTION
## Summary

- Update cosmetic repo name references from old names (`f5xc-docs-builder`, `f5xc-docs-theme`) to current names (`docs-builder`, `docs-theme`) across prose, labels, and workflow step names
- Functional references (npm dependency, `node_modules` paths, `npm install` commands) are intentionally unchanged since the npm package is still published as `f5xc-docs-theme`
- No behavioral changes — only documentation prose and metadata labels

## Test plan

- [ ] Verify `grep -r 'f5xc-docs-builder' --include='*.mdx' --include='*.yml' docs/ .github/` returns no results
- [ ] Verify `grep -r 'f5xc-docs-theme' --include='*.mdx' docs/` returns only code examples with real paths/commands
- [ ] Docker build workflow passes (npm install still uses real package name)
- [ ] Pages deploy works (no functional changes)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)