### PR TITLE
feat: add MODE=dev to entrypoint and simplify content authors docs

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -44,6 +44,23 @@ if [ -z "$DOCS_SITE" ] && [ -n "$GITHUB_REPOSITORY_OWNER" ]; then
   export DOCS_SITE
 fi
 
+# Auto-detect static asset directories (no .md/.mdx files) and symlink to public
+for dir in "$CONTENT_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  dirname=$(basename "$dir")
+  # Skip if directory contains any .md or .mdx files
+  if ! find "$dir" -maxdepth 1 -name '*.md' -o -name '*.mdx' | grep -q .; then
+    ln -sfn "$dir" "/app/public/$dirname"
+    echo "Static asset directory detected: $dirname"
+  fi
+done
+
+# Dev mode: run live dev server instead of building
+if [ "$MODE" = "dev" ]; then
+  echo "Starting dev server..."
+  exec npx astro dev --host
+fi
+
 # Build
 npm run build
 

--- a/docs/content-authors.mdx
+++ b/docs/content-authors.mdx
@@ -1,172 +1,52 @@
 ---
 title: Local Preview for Content Authors
-description: How to preview documentation locally using the published Docker image before pushing changes.
+description: Preview your documentation locally with a single Docker command.
 sidebar:
   order: 7
 ---
 
-Content repos contain only Markdown/MDX files — no framework code, no Astro config, no `node_modules`. To preview your docs locally, you run the published Docker image against your content directory.
-
-## How It Works
-
-Three repos collaborate to produce the final site:
-
-| Repo | Artifact | Role |
-|------|----------|------|
-| **docs-theme** | npm package | Astro/Starlight config, CSS, logos, plugins |
-| **docs-builder** | Docker image | Pulls the theme at runtime, compiles MDX to static HTML |
-| **docs-control** | Reusable GitHub workflow | Orchestrates the container in CI, deploys to GitHub Pages |
-
-Content repos only depend on the Docker image — everything else is handled automatically.
+Preview your docs locally before pushing changes. All you need is Docker and a `docs/` directory.
 
 ## Prerequisites
 
-- Docker installed and running
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
 - Your content repo cloned locally with a `docs/` directory containing at least `index.mdx`
 
-## Live Dev Server (recommended)
+## Start the Dev Server
 
-Override the container entrypoint to run `astro dev` instead of the production build:
+From the root of your content repo, run:
 
 ```sh
 docker run --rm -it \
   -v "$(pwd)/docs:/content/docs" \
   -p 4321:4321 \
-  --entrypoint sh \
-  ghcr.io/f5xc-salesdemos/docs-builder:latest \
-  -c '
-    npm install --legacy-peer-deps && npm update --legacy-peer-deps
-    cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
-    cp /app/node_modules/f5xc-docs-theme/src/content.config.ts /app/src/content.config.ts
-    cp -r /content/docs/* /app/src/content/docs/
-    DOCS_TITLE=$(grep -m1 "^title:" /app/src/content/docs/index.mdx | sed "s/title: *[\"]*//;s/[\"]*$//") \
-    npx astro dev --host
-  '
+  -e MODE=dev \
+  ghcr.io/f5xc-salesdemos/docs-builder:latest
 ```
 
-Open `http://localhost:4321` in your browser once the server starts.
-
-This command mirrors the steps from `entrypoint.sh` — update dependencies, copy the theme config (single source of truth), inject your content, extract the title — then starts a dev server instead of building.
+Open **http://localhost:4321** once the server starts.
 
 :::note
-File changes on your host require restarting the container. The volume is copied into the content collection directory at startup, not symlinked, so Astro's file watcher does not see host-side edits. Stop the container with `Ctrl+C` and re-run the command to pick up changes.
+File changes on your host require restarting the container. Stop it with `Ctrl+C` and re-run the command to pick up edits.
 :::
 
-If your `docs/` directory contains static asset subdirectories (e.g., `docs/images/`, `docs/diagrams/` — folders with no `.md`/`.mdx` files), add a volume mount for each so they are served as public assets:
+## Images and Static Assets
 
-```sh
-docker run --rm -it \
-  -v "$(pwd)/docs:/content/docs" \
-  -v "$(pwd)/docs/images:/app/public/images:ro" \
-  -p 4321:4321 \
-  --entrypoint sh \
-  ghcr.io/f5xc-salesdemos/docs-builder:latest \
-  -c '
-    npm install --legacy-peer-deps && npm update --legacy-peer-deps
-    cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
-    cp /app/node_modules/f5xc-docs-theme/src/content.config.ts /app/src/content.config.ts
-    cp -r /content/docs/* /app/src/content/docs/
-    DOCS_TITLE=$(grep -m1 "^title:" /app/src/content/docs/index.mdx | sed "s/title: *[\"]*//;s/[\"]*$//") \
-    npx astro dev --host
-  '
-```
+Place images in a subdirectory like `docs/images/`. The container detects these automatically — no extra volume mounts needed.
 
-This mirrors the [Static Assets](#static-assets) section below — the same volume mounts apply to both the dev server and the production build.
-
-## Static Build (production preview)
-
-For a full production build that matches CI output, pass `GITHUB_REPOSITORY` so the base path is derived correctly:
-
-```sh
-docker run --rm \
-  -v "$(pwd)/docs:/content/docs:ro" \
-  -v "$(pwd)/output:/output" \
-  -e GITHUB_REPOSITORY="f5xc-salesdemos/my-docs" \
-  ghcr.io/f5xc-salesdemos/docs-builder:latest
-```
-
-Replace `f5xc-salesdemos/my-docs` with your actual `owner/repo`. This sets `DOCS_BASE` to `/my-docs`, matching how GitHub Pages serves project sites under a subpath.
-
-Then serve the output with the correct base path:
-
-```sh
-npx serve output/ -l 8080
-```
-
-Open `http://localhost:8080/my-docs/` (substituting your repo name).
-
-:::tip
-If you omit `GITHUB_REPOSITORY`, the site builds with no base path. Links and assets will work at the root (`http://localhost:8080/`) but won't match the CI output exactly.
-:::
-
-## Static Assets
-
-The CI workflow automatically detects subdirectories in `docs/` that contain no `.md` or `.mdx` files (e.g., `docs/images/`, `docs/diagrams/`) and mounts them as static assets at `/app/public/<dirname>`. This makes them available at the site root without going through the content collection.
-
-To replicate this locally, add an extra volume mount for each static asset directory:
-
-```sh
-docker run --rm \
-  -v "$(pwd)/docs:/content/docs:ro" \
-  -v "$(pwd)/docs/images:/app/public/images:ro" \
-  -v "$(pwd)/output:/output" \
-  -e GITHUB_REPOSITORY="f5xc-salesdemos/my-docs" \
-  ghcr.io/f5xc-salesdemos/docs-builder:latest
-```
-
-Reference these assets in your MDX with a root-relative path:
+Reference them in your MDX with a root-relative path:
 
 ```mdx
 ![Architecture diagram](/images/architecture.png)
 ```
 
-## Environment Variables
-
-The Docker image supports several environment variables for customizing the build. See the [Environment Variables table in Docker Build](../docker/#environment-variables) for the core list.
-
-For local preview, the most useful overrides are:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DOCS_TITLE` | *(extracted from index.mdx)* | Override the site title |
-| `DOCS_BASE` | *(derived from `GITHUB_REPOSITORY`)* | Override the base path |
-| `GITHUB_REPOSITORY` | *(unset locally)* | `owner/repo` — used to derive `DOCS_BASE` |
-| `DOCS_DESCRIPTION` | *(extracted from index.mdx)* | Site description from frontmatter |
-| `DOCS_SITE` | *(derived from `GITHUB_REPOSITORY_OWNER`)* | Site URL passed to Astro (e.g., `https://<owner>.github.io`) |
-| `GENERATE_PDF` | `false` | Enable PDF generation after build |
-| `PDF_FILENAME` | `docs` | Output filename for the generated PDF |
-| `LLMS_OPTIONAL_LINKS` | `[]` | JSON array of child site URLs for the `llms.txt` Optional section |
-
-Pass them with `-e`:
-
-```sh
-docker run --rm -it \
-  -e DOCS_TITLE="My Local Preview" \
-  -e GITHUB_REPOSITORY="f5xc-salesdemos/my-docs" \
-  -v "$(pwd)/docs:/content/docs" \
-  -p 4321:4321 \
-  --entrypoint sh \
-  ghcr.io/f5xc-salesdemos/docs-builder:latest \
-  -c '...'
-```
-
 ## Troubleshooting
 
-**Port already in use** — If port 4321 is taken, map to a different host port:
+**Port already in use** — Map to a different host port: `-p 8080:4321`, then open `http://localhost:8080`.
 
-```sh
--p 8080:4321
-```
+**Content not appearing** — Verify `docs/index.mdx` exists. Check the container output for an `ERROR: No content found` message.
 
-Then open `http://localhost:8080`.
-
-**Permission denied on volume mount** — Ensure Docker has access to the directory you are mounting. On macOS, the path must be within a shared directory in Docker Desktop settings. On Linux, check that the user running Docker has read access to `docs/`.
-
-**Content not appearing** — Verify your `docs/` directory contains an `index.mdx` file. The entrypoint expects at least this file to exist. Check the container logs for an `ERROR: No content found` message.
-
-**Base path mismatch** — If links or assets return 404 in the static build, make sure you passed `-e GITHUB_REPOSITORY="owner/repo"` and are serving the output at the matching subpath (e.g., `http://localhost:8080/repo/`).
-
-**Dev server crashes on startup** — If you see Astro config errors, the theme package may have updated. Pull the latest image:
+**Stale image** — Pull the latest version:
 
 ```sh
 docker pull ghcr.io/f5xc-salesdemos/docs-builder:latest
@@ -174,5 +54,5 @@ docker pull ghcr.io/f5xc-salesdemos/docs-builder:latest
 
 ## Further Reading
 
-- [Docker Build](../docker/) — Image layers, entrypoint details, and environment variables
+- [Docker Build](../docker/) — Image details, environment variables, and production builds
 - [Architecture](../architecture/) — Content injection model and theme system design


### PR DESCRIPTION
## Summary

- Add `MODE=dev` env var to `docker/entrypoint.sh` — when set, runs `npx astro dev --host` instead of `npm run build`, giving content authors a one-command dev server
- Auto-detect static asset directories (e.g. `docs/images/`) and symlink them to `/app/public/` so manual `-v` mounts are no longer needed
- Rewrite `docs/content-authors.mdx` from 179 lines to 59 — removes architecture tables, obsolete npm commands, production build instructions, and environment variable references that are irrelevant to content authors

Content authors now run:
```sh
docker run --rm -it \
  -v "$(pwd)/docs:/content/docs" \
  -p 4321:4321 \
  -e MODE=dev \
  ghcr.io/f5xc-salesdemos/docs-builder:latest
```

Instead of a 13-line command with `--entrypoint sh` overrides.

Closes #74

## Test plan

- [x] Build test image locally: `docker build -f docker/Dockerfile -t docs-builder-test .`
- [x] Dev mode starts and serves pages at http://localhost:4321
- [x] Production mode (no MODE env) builds successfully — existing behavior unchanged
- [x] PDF generation path unaffected (runs after the dev-mode exit point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)