### PR TITLE
fix: skip symlink when static asset directory is already mounted

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -50,8 +50,13 @@ for dir in "$CONTENT_DIR"/*/; do
   dirname=$(basename "$dir")
   # Skip if directory contains any .md or .mdx files
   if ! find "$dir" -maxdepth 1 -name '*.md' -o -name '*.mdx' | grep -q .; then
-    ln -sfn "$dir" "/app/public/$dirname"
-    echo "Static asset directory detected: $dirname"
+    # Skip if already mounted by the CI workflow (avoids read-only mount conflict)
+    if [ -e "/app/public/$dirname" ]; then
+      echo "Static asset directory already mounted: $dirname"
+    else
+      ln -sfn "$dir" "/app/public/$dirname"
+      echo "Static asset directory detected: $dirname"
+    fi
   fi
 done
 


### PR DESCRIPTION
## Summary
- Added a guard in the entrypoint to skip `ln -sfn` when `/app/public/<dirname>` already exists
- Fixes the `ln: /app/public/brand-icons/brand-icons: Read-only file system` error that occurs when the reusable workflow pre-mounts static asset directories as read-only Docker volumes
- The entrypoint and workflow now coexist: if the workflow mounted the directory, the entrypoint skips it; if not (e.g. local `docker run`), the entrypoint creates the symlink as before

Closes #76

## Test plan
- [ ] Merge and verify the docs-builder Docker image rebuilds successfully
- [ ] Re-run the GitHub Pages Deploy workflow in `docs-theme` — confirm the `brand-icons` error is gone
- [ ] Verify local `docker run` without volume mounts still creates symlinks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)