### PR TITLE
feat: add @robinmordasiewicz/icons-f5xc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@iconify-json/tabler": "^1.2.26",
     "@robinmordasiewicz/icons-carbon": "^0.1.0",
     "@robinmordasiewicz/icons-f5-brand": "^0.1.0",
+    "@robinmordasiewicz/icons-f5xc": "^0.1.0",
     "@robinmordasiewicz/icons-hashicorp-flight": "^0.1.0",
     "@robinmordasiewicz/icons-lucide": "^0.1.0",
     "@robinmordasiewicz/icons-mdi": "^0.1.0",


### PR DESCRIPTION
## Summary

- Add `@robinmordasiewicz/icons-f5xc` (`^0.1.0`) to dependencies so the 30 F5 Distributed Cloud service icons are available in the docs-builder container

## Test plan

- [ ] Docker image builds successfully with the new dependency
- [ ] Icon package is accessible from Astro components in content repos

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)