### PR TITLE
fix: update f5xc icons to 0.3.0 for dark mode CSS variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@lucide/astro": "^0.574.0",
         "@robinmordasiewicz/icons-carbon": "*",
         "@robinmordasiewicz/icons-f5-brand": "*",
-        "@robinmordasiewicz/icons-f5xc": "*",
+        "@robinmordasiewicz/icons-f5xc": "^0.3.0",
         "@robinmordasiewicz/icons-hashicorp-flight": "*",
         "@robinmordasiewicz/icons-lucide": "*",
         "@robinmordasiewicz/icons-mdi": "*",
@@ -2603,9 +2603,9 @@
       "license": "MIT"
     },
     "node_modules/@robinmordasiewicz/icons-f5xc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/icons-f5xc/-/icons-f5xc-0.2.0.tgz",
-      "integrity": "sha512-ysY4GsB56mbt9j82WEdRQKuD8ycUe7bkviePVpfVugBp+TFYOJYHWEBsu+Y5em4Al+D3Hs8HPvA/4mDWoKquQQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/icons-f5xc/-/icons-f5xc-0.3.0.tgz",
+      "integrity": "sha512-Qv56kDh8i75Ciuw5axX6cbcDbL55qeGBJNnflSmkgLzllDfgI6A7jDebPmLj2x9Oi/bl9gERfOieU+qGt1pXAg==",
       "license": "MIT"
     },
     "node_modules/@robinmordasiewicz/icons-hashicorp-flight": {
@@ -11638,13 +11638,6 @@
         "url": "https://github.com/sponsors/dcastil"
       }
     },
-    "node_modules/tailwindcss": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/tar-fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -11842,20 +11835,6 @@
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "license": "MIT"
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",


### PR DESCRIPTION
## Summary

- Update `@robinmordasiewicz/icons-f5xc` from `0.2.0` to `0.3.0` in `package-lock.json`
- Version 0.3.0 includes dark mode support via CSS custom properties (`var(--color-N600, ...)`)
- The lockfile was pinned to 0.2.0, so `npm ci` in the Dockerfile was not picking up the updated package

Closes #103

## Test plan

- [ ] Docker image rebuild installs `@robinmordasiewicz/icons-f5xc@0.3.0`
- [ ] docs-icons site icons render with CSS variables (not hardcoded hex)
- [ ] Icons adapt correctly when toggling light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)