### PR TITLE
feat: add retry logic to Docker multi-platform build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -38,15 +38,33 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+      - name: Build and push with retry
+        run: |
+          MAX_ATTEMPTS=3
+          DELAY=60
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Build attempt $attempt of $MAX_ATTEMPTS"
+            if docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --tag "${{ env.IMAGE_NAME }}:latest" \
+              --tag "${{ env.IMAGE_NAME }}:${{ github.sha }}" \
+              --file docker/Dockerfile \
+              --push \
+              .; then
+              echo "::endgroup::"
+              echo "Build succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "::warning::Build failed on attempt $attempt"
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Waiting ${DELAY}s before retry..."
+              sleep $DELAY
+              DELAY=$((DELAY * 2))
+            fi
+          done
+          echo "::error::All $MAX_ATTEMPTS build attempts failed"
+          exit 1
 
   dispatch:
     name: Trigger downstream Pages rebuilds


### PR DESCRIPTION
## Summary
- Replace `docker/build-push-action@v6` with a shell-based `docker buildx build` command wrapped in retry logic
- Retries up to 3 times with exponential backoff (60s, 120s) to handle transient QEMU crashes during arm64 emulation
- Uses GitHub Actions `::group::`, `::warning::`, and `::error::` annotations for clear build log output

Closes #104

## Test plan
- [ ] Merge and verify the Docker build workflow runs successfully
- [ ] Confirm multi-platform image is pushed to ghcr.io with both `latest` and SHA tags
- [ ] Verify downstream dispatch triggers after successful build

🤖 Generated with [Claude Code](https://claude.com/claude-code)