### PR TITLE
fix: update @robinmordasiewicz/icons-f5xc to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@lucide/astro": "^0.574.0",
         "@robinmordasiewicz/icons-carbon": "*",
         "@robinmordasiewicz/icons-f5-brand": "*",
-        "@robinmordasiewicz/icons-f5xc": "^0.3.0",
+        "@robinmordasiewicz/icons-f5xc": "^0.3.1",
         "@robinmordasiewicz/icons-hashicorp-flight": "*",
         "@robinmordasiewicz/icons-lucide": "*",
         "@robinmordasiewicz/icons-mdi": "*",
@@ -2603,9 +2603,9 @@
       "license": "MIT"
     },
     "node_modules/@robinmordasiewicz/icons-f5xc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/icons-f5xc/-/icons-f5xc-0.3.0.tgz",
-      "integrity": "sha512-Qv56kDh8i75Ciuw5axX6cbcDbL55qeGBJNnflSmkgLzllDfgI6A7jDebPmLj2x9Oi/bl9gERfOieU+qGt1pXAg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/icons-f5xc/-/icons-f5xc-0.3.1.tgz",
+      "integrity": "sha512-hHN8wxDTWk1nuLqdFZjb3HS7fLBwfObkDhMcOHEaTdKT3bGFrbqPWNVz+gk4YL/d7ZAOp/QKWJ4Iot57KHtEZg==",
       "license": "MIT"
     },
     "node_modules/@robinmordasiewicz/icons-hashicorp-flight": {


### PR DESCRIPTION
## Summary
- Update package-lock.json to resolve @robinmordasiewicz/icons-f5xc@0.3.1
- Picks up fix for stroke-only SVG paths that were inheriting `fill="currentColor"` instead of `fill="none"`

Closes #106

## Test plan
- [ ] Docker image rebuilds with icons-f5xc 0.3.1
- [ ] nginx-one icon shows transparent hexagon (not filled) in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)