### PR TITLE
fix: update @robinmordasiewicz/icons-f5xc to 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@lucide/astro": "^0.574.0",
         "@robinmordasiewicz/icons-carbon": "*",
         "@robinmordasiewicz/icons-f5-brand": "*",
-        "@robinmordasiewicz/icons-f5xc": "^0.3.1",
+        "@robinmordasiewicz/icons-f5xc": "^0.3.2",
         "@robinmordasiewicz/icons-hashicorp-flight": "*",
         "@robinmordasiewicz/icons-lucide": "*",
         "@robinmordasiewicz/icons-mdi": "*",
@@ -2603,9 +2603,9 @@
       "license": "MIT"
     },
     "node_modules/@robinmordasiewicz/icons-f5xc": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/icons-f5xc/-/icons-f5xc-0.3.1.tgz",
-      "integrity": "sha512-hHN8wxDTWk1nuLqdFZjb3HS7fLBwfObkDhMcOHEaTdKT3bGFrbqPWNVz+gk4YL/d7ZAOp/QKWJ4Iot57KHtEZg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/icons-f5xc/-/icons-f5xc-0.3.2.tgz",
+      "integrity": "sha512-PEk5dOHOZlqOmjFj3MGWRQvAdI8az6r4VCLpsTzbQHmd2A8MQaac8foyaRmjoOR+44c4XsF3EtWR7bwpTQdh4Q==",
       "license": "MIT"
     },
     "node_modules/@robinmordasiewicz/icons-hashicorp-flight": {


### PR DESCRIPTION
## Summary
- Update lockfile to @robinmordasiewicz/icons-f5xc@0.3.2
- Picks up contrasting fill for nginx-one hexagon (light fill in light mode, dark fill in dark mode)

Closes #108

## Test plan
- [ ] Docker image rebuilds successfully
- [ ] nginx-one icon shows visible "ONE" text in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)