### PR TITLE
fix: update lockfile for icons-hashicorp-flight 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "@lucide/astro": "^0.574.0",
         "@robinmordasiewicz/icons-carbon": "*",
         "@robinmordasiewicz/icons-f5-brand": "*",
-        "@robinmordasiewicz/icons-f5xc": "^0.3.2",
-        "@robinmordasiewicz/icons-hashicorp-flight": "*",
+        "@robinmordasiewicz/icons-f5xc": "*",
+        "@robinmordasiewicz/icons-hashicorp-flight": "^0.3.0",
         "@robinmordasiewicz/icons-lucide": "*",
         "@robinmordasiewicz/icons-mdi": "*",
         "@robinmordasiewicz/icons-phosphor": "*",
@@ -2609,9 +2609,9 @@
       "license": "MIT"
     },
     "node_modules/@robinmordasiewicz/icons-hashicorp-flight": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/icons-hashicorp-flight/-/icons-hashicorp-flight-0.2.0.tgz",
-      "integrity": "sha512-qdQuQN8b42El+zCO92jAABbSeGFYy4pvsdw9mxeU1T6hmelHaVuLVJ/cOMdh6l82346kQdOuontsGx1Px/No7g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/icons-hashicorp-flight/-/icons-hashicorp-flight-0.3.0.tgz",
+      "integrity": "sha512-xmIpynBNSYXnuqSdgSdzkth0Ubrt6FqraFmysQpwXQqVKTQux7riL3xXDxzclNzTnZ3+LILmprc5MzPD+PV5Hg==",
       "license": "MIT",
       "dependencies": {
         "@hashicorp/flight-icons": "^4.2.0"


### PR DESCRIPTION
## Summary
- Updates `package-lock.json` to resolve `@robinmordasiewicz/icons-hashicorp-flight@0.3.0`
- This version includes the `instagram-color` icon added in docs-icons PR #57

## Context
The hashicorp-flight package version was bumped to 0.3.0 in docs-icons PR #66, but the docs-builder lockfile still resolved to 0.2.0 (without instagram-color). This caused Pages deploy failures.

## Test plan
- [ ] Docker image rebuilds with hashicorp-flight 0.3.0
- [ ] Pages deploy succeeds with instagram-color icon

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)