### PR TITLE
fix: add sidebar order to index page for correct prev/next navigation

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,4 +5,5 @@ hero:
   tagline: A containerized Astro + Starlight build system that turns any content repo into a branded documentation site.
 sidebar:
   hidden: true
+  order: 1
 ---


### PR DESCRIPTION
## Summary

- Add `order: 1` to `docs/index.mdx` sidebar frontmatter so Starlight orders it before the other pages (orders 2–7)
- Fixes the previous/next navigation buttons at the bottom of pages being out of order

Closes #116

## Test plan

- [ ] CI passes
- [ ] Previous/next navigation buttons display in correct order on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)