### PR TITLE
fix: create public/ directory before symlinking static assets

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -52,6 +52,9 @@ if [ -z "$DOCS_SITE" ] && [ -n "$GITHUB_REPOSITORY_OWNER" ]; then
   export DOCS_SITE
 fi
 
+# Ensure public directory exists for static asset symlinks
+mkdir -p /app/public
+
 # Auto-detect static asset directories (no .md/.mdx files) and symlink to public
 for dir in "$CONTENT_DIR"/*/; do
   [ -d "$dir" ] || continue


### PR DESCRIPTION
## Summary
- Add `mkdir -p /app/public` in `docker/entrypoint.sh` before the static asset symlink loop
- Fixes `ln: /app/public/<dir>: No such file or directory` errors when content repos contain static asset directories (e.g., `images/`, `logos/`)
- `mkdir -p` is idempotent — safe if the directory already exists

## Test plan
- [ ] Super-linter CI passes
- [ ] Docker image builds successfully
- [ ] Content repos with static asset directories no longer produce symlink errors
- [ ] Post-merge Docker image rebuild workflow succeeds

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)