### PR TITLE
fix: add write-permission check before copying to /output

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -129,5 +129,11 @@ fi
 
 # Copy output
 if [ -d "$OUTPUT_DIR" ]; then
+  if [ ! -w "$OUTPUT_DIR" ]; then
+    echo "ERROR: Output directory $OUTPUT_DIR is not writable by UID $(id -u)."
+    echo "If running in CI, ensure the workflow sets proper permissions on the mounted volume."
+    echo "Example: chmod 777 \$RUNNER_TEMP/docs-output  (before docker run)"
+    exit 1
+  fi
   cp -r /app/dist/* "$OUTPUT_DIR"/
 fi


### PR DESCRIPTION
## Summary
- Adds a write-permission check in `docker/entrypoint.sh` before the
  `cp -r /app/dist/* "$OUTPUT_DIR"/` command
- Detects UID mismatch early and exits with an actionable error message
  instead of a cryptic `cp: can't create '/output/index.html': Permission denied`
- No behavior change when permissions are correct

## Background
After the docs-theme v2.0.4 Dependabot bump rebuilt the Docker image,
downstream content repos fail GitHub Pages Deploy because the CI runner
(UID 1001) owns the mounted `/output` directory while the container runs
as `node` (UID 1000). The actual permission fix must be done in
docs-control#167; this PR improves the container-side error reporting.

## Test plan
- [ ] CI super-linter passes (shellcheck/shfmt on the updated script)
- [ ] Docker image builds successfully
- [ ] Confirm error message fires when `/output` is not writable:
  ```bash
  mkdir -p /tmp/test-output && chmod 000 /tmp/test-output
  docker run --rm \
    -v "$(pwd)/docs:/content/docs:ro" \
    -v /tmp/test-output:/output \
    -e GITHUB_REPOSITORY="test/repo" \
    ghcr.io/f5xc-salesdemos/docs-builder:latest
  # Should see: "ERROR: Output directory /output is not writable..."
  chmod 777 /tmp/test-output && rm -rf /tmp/test-output
  ```

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)