### PR TITLE
fix: copy button now uses substituted placeholder values

### DIFF
--- a/src/scripts/placeholder-dom.ts
+++ b/src/scripts/placeholder-dom.ts
@@ -56,6 +56,16 @@ function updateSpans(values: Record<string, string>) {
   });
 }
 
+function updateCopyButtons(values: Record<string, string>) {
+  document.querySelectorAll<HTMLButtonElement>('button[data-code]').forEach((btn) => {
+    if (!btn.hasAttribute('data-code-template')) {
+      btn.setAttribute('data-code-template', btn.getAttribute('data-code') || '');
+    }
+    const template = btn.getAttribute('data-code-template') || '';
+    btn.setAttribute('data-code', substituteText(template, values));
+  });
+}
+
 async function renderMermaidDiagrams(values: Record<string, string>) {
   const containers = document.querySelectorAll<HTMLElement>('.mermaid-container');
   if (containers.length === 0) return;
@@ -98,6 +108,7 @@ async function renderMermaidDiagrams(values: Record<string, string>) {
 function handleChange(e: Event) {
   const values = (e as CustomEvent).detail as Record<string, string>;
   updateSpans(values);
+  updateCopyButtons(values);
   renderMermaidDiagrams(values);
 }
 
@@ -105,6 +116,7 @@ function init() {
   const values = getAllValues(loadValues());
   const content = document.querySelector('.sl-markdown-content') || document.body;
   walkTextNodes(content, values);
+  updateCopyButtons(values);
   renderMermaidDiagrams(values);
 }
 


### PR DESCRIPTION
## Summary

- Adds `updateCopyButtons(values)` to `placeholder-dom.ts` that patches `data-code` on all Expressive Code copy buttons with substituted values
- Stores the original template in `data-code-template` on first call so re-substitution always uses the original `xKEYx` strings
- Calls `updateCopyButtons` from both `init()` (page load) and `handleChange()` (form input events)

Closes #208

## Test plan

- [ ] Open a page with placeholder form and code blocks (e.g. `/csd/api-reference/`)
- [ ] Enter a custom API token in the placeholder form
- [ ] Click the copy button on a `curl` code block
- [ ] Paste into a text editor — confirm it contains the entered value, not `xF5XC_API_TOKENx`
- [ ] Edit the token value again — confirm re-copy picks up the new value

🤖 Generated with [Claude Code](https://claude.com/claude-code)