### PR TITLE
feat: swap to @f5xc-salesdemos/starlight-llms-txt + add llms-config.json support

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -40,6 +40,20 @@ if [ -z "$LLMS_OPTIONAL_LINKS" ] && [ -f /app/src/content/docs/llms-links.json ]
   rm /app/src/content/docs/llms-links.json
 fi
 
+# Read optional LLMs configuration from llms-config.json (if present in content)
+if [ -z "$LLMS_CONFIG" ] && [ -f /app/src/content/docs/llms-config.json ]; then
+  LLMS_CONFIG=$(cat /app/src/content/docs/llms-config.json)
+  export LLMS_CONFIG
+  rm /app/src/content/docs/llms-config.json
+fi
+
+# Read optional LLMs federated sites from llms-federated-sites.json (if present in content)
+if [ -z "$LLMS_FEDERATED_SITES" ] && [ -f /app/src/content/docs/llms-federated-sites.json ]; then
+  LLMS_FEDERATED_SITES=$(cat /app/src/content/docs/llms-federated-sites.json)
+  export LLMS_FEDERATED_SITES
+  rm /app/src/content/docs/llms-federated-sites.json
+fi
+
 # Extract base path from repo name (if not set via env)
 if [ -z "$DOCS_BASE" ] && [ -n "$GITHUB_REPOSITORY" ]; then
   DOCS_BASE="/${GITHUB_REPOSITORY#*/}"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "sharp": "^0.34.5",
-    "starlight-llms-txt": "^0.8.0",
+    "@f5xc-salesdemos/starlight-llms-txt": "^1.0.0",
     "starlight-to-pdf": "^1.4.0",
     "unist-util-visit": "^5.1.0",
     "unocss": "^66.6.8"


### PR DESCRIPTION
Refs f5xc-salesdemos/xcsh#223 (Step 2)

- Swap `starlight-llms-txt@^0.8.0` to `@f5xc-salesdemos/starlight-llms-txt@^1.0.0`
- Add `llms-config.json` ingestion to entrypoint (customSets, promote, demote)
- Add `llms-federated-sites.json` ingestion to entrypoint (federatedSites for portal)

Follows existing `llms-links.json` pattern: reads JSON from content dir, exports as env var, removes file.