### PR TITLE
fix: normalize page_title frontmatter to title at build time

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,27 @@ else
   exit 1
 fi
 
+# Normalize Terraform-style page_title to Starlight-required title
+# Terraform provider doc generators use page_title; Starlight's docsSchema requires title.
+for f in $(find /app/src/content/docs -name '*.md' -o -name '*.mdx'); do
+  if head -1 "$f" | grep -q '^---'; then
+    if grep -q '^page_title:' "$f" && ! grep -q '^title:' "$f"; then
+      sed -i 's/^page_title:/title:/' "$f"
+    fi
+  fi
+done
+
+# Add frontmatter to .md files that have none (e.g., Terraform provider guide indices)
+# Starlight requires YAML frontmatter with at least a title field.
+for f in $(find /app/src/content/docs -name '*.md'); do
+  if ! head -1 "$f" | grep -q '^---'; then
+    heading=$(grep -m1 '^# ' "$f" | sed 's/^# //')
+    if [ -n "$heading" ]; then
+      sed -i "1i\\---\ntitle: \"${heading}\"\n---" "$f"
+    fi
+  fi
+done
+
 # Placeholder form: if content repo provides placeholders.json, activate
 if [ -f /app/src/content/docs/placeholders.json ]; then
   cp /app/src/content/docs/placeholders.json /app/src/data/placeholders.json

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,24 +15,28 @@ fi
 
 # Normalize Terraform-style page_title to Starlight-required title
 # Terraform provider doc generators use page_title; Starlight's docsSchema requires title.
-find /app/src/content/docs \( -name '*.md' -o -name '*.mdx' \) -print0 | while IFS= read -r -d '' f; do
-  if head -1 "$f" | grep -q '^---'; then
-    if grep -q '^page_title:' "$f" && ! grep -q '^title:' "$f"; then
-      sed -i 's/^page_title:/title:/' "$f"
+find /app/src/content/docs \( -name '*.md' -o -name '*.mdx' \) -exec sh -c '
+  for f do
+    if head -1 "$f" | grep -q "^---"; then
+      if grep -q "^page_title:" "$f" && ! grep -q "^title:" "$f"; then
+        sed -i "s/^page_title:/title:/" "$f"
+      fi
     fi
-  fi
-done
+  done
+' sh {} +
 
 # Add frontmatter to .md files that have none (e.g., Terraform provider guide indices)
 # Starlight requires YAML frontmatter with at least a title field.
-find /app/src/content/docs -name '*.md' -print0 | while IFS= read -r -d '' f; do
-  if ! head -1 "$f" | grep -q '^---'; then
-    heading=$(grep -m1 '^# ' "$f" | sed 's/^# //')
-    if [ -n "$heading" ]; then
-      sed -i "1i\\---\ntitle: \"${heading}\"\n---" "$f"
+find /app/src/content/docs -name '*.md' -exec sh -c '
+  for f do
+    if ! head -1 "$f" | grep -q "^---"; then
+      heading=$(grep -m1 "^# " "$f" | sed "s/^# //")
+      if [ -n "$heading" ]; then
+        { printf "---\ntitle: \"%s\"\n---\n" "$heading"; cat "$f"; } > "${f}.tmp" && mv "${f}.tmp" "$f"
+      fi
     fi
-  fi
-done
+  done
+' sh {} +
 
 # Placeholder form: if content repo provides placeholders.json, activate
 if [ -f /app/src/content/docs/placeholders.json ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 
 # Normalize Terraform-style page_title to Starlight-required title
 # Terraform provider doc generators use page_title; Starlight's docsSchema requires title.
-for f in $(find /app/src/content/docs -name '*.md' -o -name '*.mdx'); do
+find /app/src/content/docs \( -name '*.md' -o -name '*.mdx' \) -print0 | while IFS= read -r -d '' f; do
   if head -1 "$f" | grep -q '^---'; then
     if grep -q '^page_title:' "$f" && ! grep -q '^title:' "$f"; then
       sed -i 's/^page_title:/title:/' "$f"
@@ -25,7 +25,7 @@ done
 
 # Add frontmatter to .md files that have none (e.g., Terraform provider guide indices)
 # Starlight requires YAML frontmatter with at least a title field.
-for f in $(find /app/src/content/docs -name '*.md'); do
+find /app/src/content/docs -name '*.md' -print0 | while IFS= read -r -d '' f; do
   if ! head -1 "$f" | grep -q '^---'; then
     heading=$(grep -m1 '^# ' "$f" | sed 's/^# //')
     if [ -n "$heading" ]; then


### PR DESCRIPTION
Refs f5xc-salesdemos/xcsh#223

## Problem
`terraform-provider-f5xc` (and potentially other repos using Terraform provider doc generators) produces docs with `page_title:` in YAML frontmatter. Starlight's `docsSchema()` requires `title:`. Build fails with `InvalidContentEntryDataError`.

Manually editing generated files is incorrect — it triggers the repo's Constitution Check ("PR contains generated files").

## Fix
Add two preprocessing steps to `docker/entrypoint.sh`, after content injection:

1. **Rename `page_title` → `title`** in files that have frontmatter but no `title` field
2. **Generate frontmatter** from the first `#` heading for `.md` files that have no frontmatter at all

Both steps run before Astro build, same pattern as existing `llms-config.json` and `placeholders.json` preprocessing.

## Effect
- terraform-provider-f5xc builds will succeed without manual edits to generated docs
- Any future repo using Terraform-style doc conventions will work automatically
- No changes to docs-theme or content.config.ts required