### PR TITLE
feat: load llms-federated-site-categories.json from content repos

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -96,6 +96,20 @@ if [ -z "$LLMS_FEDERATED_SITES" ] && [ -f /app/src/content/docs/llms-federated-s
   fi
 fi
 
+# Read optional LLMs federated site categories from llms-federated-site-categories.json
+if [ -z "$LLMS_FEDERATED_SITE_CATEGORIES" ] && [ -f /app/src/content/docs/llms-federated-site-categories.json ]; then
+  LLMS_FEDERATED_SITE_CATEGORIES=$(cat /app/src/content/docs/llms-federated-site-categories.json)
+
+  if ! echo "$LLMS_FEDERATED_SITE_CATEGORIES" | python3 -m json.tool >/dev/null 2>&1; then
+    echo "WARNING: llms-federated-site-categories.json is invalid JSON — ignoring, using defaults"
+    unset LLMS_FEDERATED_SITE_CATEGORIES
+  else
+    export LLMS_FEDERATED_SITE_CATEGORIES
+    rm /app/src/content/docs/llms-federated-site-categories.json
+    echo "LLMs federated site categories loaded"
+  fi
+fi
+
 # Extract base path from repo name (if not set via env)
 if [ -z "$DOCS_BASE" ] && [ -n "$GITHUB_REPOSITORY" ]; then
   DOCS_BASE="/${GITHUB_REPOSITORY#*/}"


### PR DESCRIPTION
## Summary

- Add support for reading `llms-federated-site-categories.json` from content repos in the docs-builder entrypoint
- Exports the file contents as the `LLMS_FEDERATED_SITE_CATEGORIES` environment variable with JSON validation
- Follows the same pattern used for `llms-federated-sites.json` (validate, export, remove)

Closes #443

## Test plan

- [ ] CI checks pass (lint, linked issue check)
- [ ] Verify entrypoint loads `llms-federated-site-categories.json` when present in content docs directory
- [ ] Verify invalid JSON is rejected with a warning and the variable is unset
- [ ] Verify pre-set `LLMS_FEDERATED_SITE_CATEGORIES` environment variable is not overwritten