### PR TITLE
feat(i18n): add locale-aware content detection to entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,15 @@ else
   exit 1
 fi
 
+# Detect locale-aware content structure
+DOCS_ROOT="/app/src/content/docs"
+if [ -d "$DOCS_ROOT/en" ]; then
+  EN_ROOT="$DOCS_ROOT/en"
+  echo "Locale-aware content detected (en/ subdirectory)"
+else
+  EN_ROOT="$DOCS_ROOT"
+fi
+
 # Normalize Terraform-style page_title to Starlight-required title
 # Terraform provider doc generators use page_title; Starlight's docsSchema requires title.
 # Note: This transform handles single-line page_title values only.
@@ -50,14 +59,14 @@ if [ -f /app/src/content/docs/placeholders.json ]; then
 fi
 
 # Extract title from index.mdx frontmatter (if not set via env)
-if [ -z "$DOCS_TITLE" ] && [ -f /app/src/content/docs/index.mdx ]; then
-  DOCS_TITLE=$(grep -m1 '^title:' /app/src/content/docs/index.mdx | sed 's/title: *["]*//;s/["]*$//' || echo "Documentation")
+if [ -z "$DOCS_TITLE" ] && [ -f "$EN_ROOT/index.mdx" ]; then
+  DOCS_TITLE=$(grep -m1 '^title:' "$EN_ROOT/index.mdx" | sed 's/title: *["]*//;s/["]*$//' || echo "Documentation")
   export DOCS_TITLE
 fi
 
 # Extract description from index.mdx frontmatter (if not set via env)
-if [ -z "$DOCS_DESCRIPTION" ] && [ -f /app/src/content/docs/index.mdx ]; then
-  DOCS_DESCRIPTION=$(grep -m1 '^description:' /app/src/content/docs/index.mdx | sed 's/description: *["]*//;s/["]*$//' || echo "")
+if [ -z "$DOCS_DESCRIPTION" ] && [ -f "$EN_ROOT/index.mdx" ]; then
+  DOCS_DESCRIPTION=$(grep -m1 '^description:' "$EN_ROOT/index.mdx" | sed 's/description: *["]*//;s/["]*$//' || echo "")
   export DOCS_DESCRIPTION
 fi
 


### PR DESCRIPTION
## Summary

- Add locale detection block to detect `en/` subdirectory after content injection
- Update title/description extraction to use locale-aware path
- Backward compatible — falls back to content root when no `en/` exists

## Changes

Only `docker/entrypoint.sh`:
1. After content copy, set `$EN_ROOT` to `en/` subdirectory if it exists, else content root
2. Title extraction uses `$EN_ROOT/index.mdx` instead of hardcoded path
3. Description extraction uses `$EN_ROOT/index.mdx` instead of hardcoded path

## Test plan

- [ ] Build succeeds with existing flat content structure (backward compat)
- [ ] Build succeeds with locale-aware `en/` content structure
- [ ] Title extracted correctly from `en/index.mdx`
- [ ] Build log shows "Locale-aware content detected" when `en/` exists

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)