### PR TITLE
fix: collapse duplicate page title for ingested Terraform-style docs

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -22,33 +22,14 @@ else
   EN_ROOT="$DOCS_ROOT"
 fi
 
-# Normalize Terraform-style page_title to Starlight-required title
-# Terraform provider doc generators use page_title; Starlight's docsSchema requires title.
-# Note: This transform handles single-line page_title values only.
-# Multiline YAML block scalar values (|- or >) are not supported.
-# Terraform-provider-f5xc uses single-line titles so this is sufficient.
-find /app/src/content/docs \( -name '*.md' -o -name '*.mdx' \) -exec sh -c '
-  for f do
-    if head -1 "$f" | grep -q "^---"; then
-      if grep -q "^page_title:" "$f" && ! grep -q "^title:" "$f"; then
-        sed -i "s/^page_title:/title:/" "$f"
-      fi
-    fi
-  done
-' sh {} +
-
-# Add frontmatter to .md files that have none (e.g., Terraform provider guide indices)
-# Starlight requires YAML frontmatter with at least a title field.
-find /app/src/content/docs -name '*.md' -exec sh -c '
-  for f do
-    if ! head -1 "$f" | grep -q "^---"; then
-      heading=$(grep -m1 "^# " "$f" | sed "s/^# //")
-      if [ -n "$heading" ]; then
-        { printf "---\ntitle: \"%s\"\n---\n" "$heading"; cat "$f"; } > "${f}.tmp" && mv "${f}.tmp" "$f"
-      fi
-    fi
-  done
-' sh {} +
+# Normalize ingested Markdown frontmatter for Starlight.
+# Terraform-style docs carry a `page_title` (browser-tab title) plus a body `# H1`
+# (visible heading); Starlight renders the frontmatter `title` AS the page <h1>, so
+# feeding both renders the title twice. The normalizer promotes the body H1 to the
+# frontmatter `title` and strips it from the body (single source of truth), and
+# renames a lone `page_title` to `title` on pages that have no body H1. Pages needing
+# no change are left untouched.
+node /app/docker/normalize-frontmatter.mjs /app/src/content/docs
 
 # Placeholder form: if content repo provides placeholders.json, activate
 if [ -f /app/src/content/docs/placeholders.json ]; then

--- a/docker/normalize-frontmatter.mjs
+++ b/docker/normalize-frontmatter.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Normalize ingested Markdown frontmatter for Starlight rendering.
+//
+// Source docs (e.g. tfplugindocs output) follow the Terraform convention where
+// `page_title` is the browser-tab title and the body's first `# H1` is the visible
+// heading. Starlight instead renders the frontmatter `title` as the page `<h1>` and
+// expects NO top-level H1 in the body. Feeding Terraform-style docs to Starlight
+// therefore renders the title twice (once from frontmatter, once from the body H1).
+//
+// This script reconciles the two conventions, choosing the body H1 as the single
+// source of truth: it promotes the first body H1 to the frontmatter `title` and
+// removes that H1 from the body. Pages without a body H1 keep today's behavior
+// (rename a lone `page_title` to `title`); pages that need no change are left
+// byte-identical.
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.argv[2];
+if (!root) {
+  console.error('usage: normalize-frontmatter.mjs <content-root>');
+  process.exit(2);
+}
+if (!existsSync(root)) {
+  console.log(`normalize-frontmatter: content root ${root} not found — nothing to do`);
+  process.exit(0);
+}
+
+// YAML double-quoted scalar: only backslash and double-quote need escaping.
+const yamlQuote = (s) => `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+const isFrontmatterFence = (line) => line.trim() === '---';
+const H1_RE = /^#[ \t]+(.+?)[ \t]*$/;
+
+// Split a file into its frontmatter lines (without the `---` fences) and body lines.
+// Returns { fm: string[] | null, body: string[] }. `fm` is null when no frontmatter.
+function split(lines) {
+  if (lines.length === 0 || !isFrontmatterFence(lines[0])) {
+    return { fm: null, body: lines };
+  }
+  for (let i = 1; i < lines.length; i++) {
+    if (isFrontmatterFence(lines[i])) {
+      return { fm: lines.slice(1, i), body: lines.slice(i + 1) };
+    }
+  }
+  // Unterminated frontmatter — treat the whole file as body, leave untouched.
+  return { fm: null, body: lines };
+}
+
+// The title H1 is the first non-blank body line, and only when it is an H1.
+// Restricting to the first non-blank line keeps us from stripping section headings
+// or `#` comments inside fenced code blocks deeper in the document.
+function findTitleH1(body) {
+  for (let i = 0; i < body.length; i++) {
+    if (body[i].trim() === '') continue;
+    const m = body[i].match(H1_RE);
+    return m ? { index: i, text: m[1] } : null;
+  }
+  return null;
+}
+
+// Drop a single leading H1 line plus at most one blank line that follows it.
+function stripH1(body, index) {
+  const out = body.slice();
+  out.splice(index, 1);
+  if (out[index] !== undefined && out[index].trim() === '') {
+    out.splice(index, 1);
+  }
+  return out;
+}
+
+// Process one file's text; return new text, or null if no change is needed.
+function normalize(text) {
+  const trailingNewline = text.endsWith('\n');
+  const lines = text.replace(/\n$/, '').split('\n');
+  const { fm, body } = split(lines);
+  const h1 = findTitleH1(body);
+
+  if (h1) {
+    // H1 wins: it becomes the frontmatter title and is removed from the body.
+    const keptFm = (fm ?? []).filter((l) => !/^(title|page_title):/.test(l));
+    const newFm = [`title: ${yamlQuote(h1.text)}`, ...keptFm];
+    const newBody = stripH1(body, h1.index);
+    // Leading blanks are absorbed into the single separator below.
+    while (newBody.length && newBody[0].trim() === '') newBody.shift();
+    const out = ['---', ...newFm, '---', '', ...newBody].join('\n');
+    return trailingNewline ? `${out}\n` : out;
+  }
+
+  // No body H1. Only act if a lone `page_title` needs renaming to `title`.
+  if (fm && fm.some((l) => /^page_title:/.test(l)) && !fm.some((l) => /^title:/.test(l))) {
+    const newFm = fm.map((l) => l.replace(/^page_title:/, 'title:'));
+    const out = ['---', ...newFm, '---', ...body].join('\n');
+    return trailingNewline ? `${out}\n` : out;
+  }
+
+  return null;
+}
+
+let changed = 0;
+const entries = readdirSync(root, { recursive: true, withFileTypes: true });
+for (const entry of entries) {
+  if (!entry.isFile()) continue;
+  if (!/\.mdx?$/.test(entry.name)) continue;
+  const path = join(entry.parentPath ?? entry.path, entry.name);
+  const next = normalize(readFileSync(path, 'utf8'));
+  if (next !== null) {
+    writeFileSync(path, next);
+    changed++;
+  }
+}
+console.log(`normalize-frontmatter: updated ${changed} file(s) under ${root}`);


### PR DESCRIPTION
## Summary

Pages built from Terraform-style docs rendered their title twice — once as the Starlight page `<h1>` (from frontmatter `title`) and again as a second `<h1>` from the markdown body (e.g. **F5XC Provider** shown twice at https://f5xc-salesdemos.github.io/terraform-provider-f5xc/en/).

The cause is a convention mismatch the pipeline failed to reconcile: Terraform docs use `page_title` (browser-tab) + a body `# H1` (visible heading), while Starlight renders the frontmatter `title` AS the visible `<h1>` and expects no body H1. `entrypoint.sh` renamed `page_title:`→`title:` but left the body H1 in place, so both rendered.

Fixed in the single DRY choke point (`docker/entrypoint.sh`) so every downstream repo is corrected with no source-file edits. The body H1 is the single source of truth: it is promoted to the frontmatter `title` and stripped from the body. As a bonus, visible titles get cleaner (`f5xc_address_allocator (Resource)` instead of `f5xc_address_allocator Resource - terraform-provider-f5xc`).

## Related Issue

Closes #677

## Changes

- Add `docker/normalize-frontmatter.mjs`: promotes the first body H1 to frontmatter `title`, strips that H1 from the body, drops a redundant `page_title`; for pages with no body H1, renames a lone `page_title`→`title` (prior behavior); leaves pages needing no change byte-identical. Handles `.md`/`.mdx`, YAML-quotes titles containing `()`/`:`, and ignores `#` lines inside fenced code blocks (only the first non-blank body line is treated as the title H1).
- `docker/entrypoint.sh`: replace the two brittle `find … -exec sh` frontmatter transforms with a single `node docker/normalize-frontmatter.mjs` invocation.

## Verification

- **Fixture** (real index + resource + guide + a no-frontmatter file): each output has exactly one `title`, no `page_title`, and no leading body H1. A hand-authored page (`title`, no body H1) is byte-identical — no regression.
- **Real render pipeline** (installed Starlight `PageTitle.astro` + `@astrojs/markdown-remark`): title side = 1 `<h1>`; content side = **0** for the fixed body vs **1** for the old buggy body → total **1 (fixed) vs 2 (bug)`**, reproducing the screenshot and proving the fix.

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions