### PR TITLE
chore(deps): remove @astrojs/mdx override (first-party accepts astro 7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@f5xc-salesdemos/icons-phosphor": "*",
         "@f5xc-salesdemos/icons-simple-icons": "*",
         "@f5xc-salesdemos/icons-tabler": "*",
-        "@f5xc-salesdemos/starlight-llms-txt": "^1.0.0",
+        "@f5xc-salesdemos/starlight-llms-txt": "^1.3.1",
         "@hashicorp/flight-icons": "^5.0.0",
         "@iconify-json/carbon": "^1.2.23",
         "@iconify-json/lucide": "^1.2.114",
@@ -1639,13 +1639,13 @@
       }
     },
     "node_modules/@f5xc-salesdemos/docs-theme": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/docs-theme/-/docs-theme-3.8.0.tgz",
-      "integrity": "sha512-SImKbELTWWBPYthTcnzmz24niqnsgThzSkFCpakC9yzJaxP374qFvSFW9p3kr84YbRjSGeN4R1VpgG75oRHOnA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/docs-theme/-/docs-theme-3.9.0.tgz",
+      "integrity": "sha512-GOzRldjfJr60XLfcX8OeeKBr8/rgN9BkO498DThG2JUWrI7MGDXlgitd7imrSB3MzckmndlO1aa5MnE8uIpqSw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.105.0",
-        "@astrojs/react": "^5.0.0",
+        "@astrojs/react": "^6.0.0",
         "@f5xc-salesdemos/i18n-core": "^1.0.0",
         "@f5xc-salesdemos/starlight-llms-txt": "1.3.0",
         "@f5xc-salesdemos/starlight-mega-menu": "^2.0.0",
@@ -1674,7 +1674,7 @@
         "@iconify-json/mdi": "*",
         "@iconify-json/ph": "*",
         "@iconify-json/tabler": "*",
-        "astro": "^6.1.9"
+        "astro": ">=6.0.0"
       },
       "peerDependenciesMeta": {
         "@f5xc-salesdemos/icons-f5-brand": {
@@ -1703,100 +1703,93 @@
         }
       }
     },
-    "node_modules/@f5xc-salesdemos/docs-theme/node_modules/@astrojs/react": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-5.0.7.tgz",
-      "integrity": "sha512-N9cCoxvnLWaP+AK1Fv4e5Mc7ktnVTpSo2nWLwvD9Ohr1dJKygwrTSm9yatqoahgb1A5Kwjg/rT2shRiIVdn3aw==",
+    "node_modules/@f5xc-salesdemos/docs-theme/node_modules/@astrojs/internal-helpers": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
+      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.0",
-        "@vitejs/plugin-react": "^5.2.0",
-        "devalue": "^5.8.1",
-        "ultrahtml": "^1.6.0",
-        "vite": "^7.3.2"
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/@f5xc-salesdemos/docs-theme/node_modules/@astrojs/mdx": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-5.0.6.tgz",
+      "integrity": "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-remark": "7.1.2",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.16.0",
+        "es-module-lexer": "^2.0.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "piccolore": "^0.1.3",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
       },
       "engines": {
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
-        "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
-        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+        "astro": "^6.0.0"
       }
     },
-    "node_modules/@f5xc-salesdemos/docs-theme/node_modules/vite": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+    "node_modules/@f5xc-salesdemos/docs-theme/node_modules/@astrojs/mdx/node_modules/@astrojs/markdown-remark": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
+      "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
+        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "js-yaml": "^4.1.1",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.0",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@f5xc-salesdemos/docs-theme/node_modules/@f5xc-salesdemos/starlight-llms-txt": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.3.0.tgz",
+      "integrity": "sha512-0d0LeWnRqFUSCetZCQLaJ2gyhNx7k5n5hcD6H6kai5Qh3DAWSi67/Jsci5G+xqMaI+R3OwmLWvfIUT/FklNR6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/mdx": "^5.0.3",
+        "@types/hast": "^3.0.4",
+        "@types/micromatch": "^4.0.10",
+        "github-slugger": "^2.0.0",
+        "hast-util-select": "^6.0.4",
+        "micromatch": "^4.0.8",
+        "rehype-parse": "^9.0.1",
+        "rehype-remark": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-remove": "^4.0.0"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
+        "@astrojs/starlight": ">=0.38.0",
+        "astro": "^6.0.0"
       }
     },
     "node_modules/@f5xc-salesdemos/i18n-core": {
@@ -1908,9 +1901,9 @@
       }
     },
     "node_modules/@f5xc-salesdemos/starlight-llms-txt": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.3.0.tgz",
-      "integrity": "sha512-0d0LeWnRqFUSCetZCQLaJ2gyhNx7k5n5hcD6H6kai5Qh3DAWSi67/Jsci5G+xqMaI+R3OwmLWvfIUT/FklNR6w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.3.1.tgz",
+      "integrity": "sha512-LvLmcV1D77hS0VebBACj/2ctQ7uIG7wr/hYqM4D9pyuvLHJrY5j+kz5ej3TMvfHHYODzglYmUC2BPf0WZ4xjzw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
@@ -1928,6 +1921,71 @@
       },
       "peerDependencies": {
         "@astrojs/starlight": ">=0.38.0",
+        "astro": ">=6.0.0"
+      }
+    },
+    "node_modules/@f5xc-salesdemos/starlight-llms-txt/node_modules/@astrojs/internal-helpers": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
+      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/@f5xc-salesdemos/starlight-llms-txt/node_modules/@astrojs/markdown-remark": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
+      "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "js-yaml": "^4.1.1",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.0",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@f5xc-salesdemos/starlight-llms-txt/node_modules/@astrojs/mdx": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-5.0.6.tgz",
+      "integrity": "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-remark": "7.1.2",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.16.0",
+        "es-module-lexer": "^2.0.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "piccolore": "^0.1.3",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
         "astro": "^6.0.0"
       }
     },
@@ -4145,7 +4203,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.62.2",
@@ -4158,7 +4217,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.2",
@@ -4171,7 +4231,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.62.2",
@@ -4184,7 +4245,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.62.2",
@@ -4197,7 +4259,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.62.2",
@@ -4210,7 +4273,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.2",
@@ -4226,7 +4290,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.2",
@@ -4242,7 +4307,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.2",
@@ -4258,7 +4324,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.2",
@@ -4274,7 +4341,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.62.2",
@@ -4290,7 +4358,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.2",
@@ -4306,7 +4375,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.2",
@@ -4322,7 +4392,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.2",
@@ -4338,7 +4409,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.2",
@@ -4354,7 +4426,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.2",
@@ -4370,7 +4443,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.2",
@@ -4386,7 +4460,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.2",
@@ -4402,7 +4477,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.62.2",
@@ -4418,7 +4494,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.62.2",
@@ -4431,7 +4508,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.62.2",
@@ -4444,7 +4522,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.2",
@@ -4457,7 +4536,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.2",
@@ -4470,7 +4550,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.2",
@@ -4483,7 +4564,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.2",
@@ -4496,7 +4578,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@scalar/agent-chat": {
       "version": "0.12.12",
@@ -12225,6 +12308,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "sharp": "^0.35.2",
-    "@f5xc-salesdemos/starlight-llms-txt": "^1.0.0",
+    "@f5xc-salesdemos/starlight-llms-txt": "^1.3.1",
     "unist-util-visit": "^5.1.0",
     "unocss": "^66.7.2"
   },
@@ -49,7 +49,6 @@
     "dompurify": "^3.4.0",
     "basic-ftp": "^5.2.1",
     "defu": "^6.1.5",
-    "@astrojs/mdx": "^7.0.0",
     "astro": "$astro"
   }
 }


### PR DESCRIPTION
Closes #702

docs-theme@3.9.0 + starlight-llms-txt@1.3.1 now declare `peer astro >=6.0.0`, so the `@astrojs/mdx ^7.0.0` override is no longer needed. Removed.

The `$astro` override stays for `@lucide/astro` (third-party, no astro 7 release yet). It'll auto-resolve when they update — Dependabot will pick it up.

Install + build verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)