### PR TITLE
fix: restamp stale translation sourceHash (unblocks Translation freshness)

### DIFF
--- a/docs/ar/architecture.mdx
+++ b/docs/ar/architecture.mdx
@@ -4,7 +4,7 @@ description: تصميم النظام، هيكل المجلدات، نظام ال
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/ar/ci-cd.mdx
+++ b/docs/ar/ci-cd.mdx
@@ -4,7 +4,7 @@ description: سير عمل GitHub Actions، مزامنة القوالب، الأ
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/ar/content-authors.mdx
+++ b/docs/ar/content-authors.mdx
@@ -4,7 +4,7 @@ description: معاينة توثيقك محلياً بأمر Docker واحد.
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/ar/docker.mdx
+++ b/docs/ar/docker.mdx
@@ -4,7 +4,7 @@ description: طبقات Dockerfile، تنسيق نقطة الدخول، متغي
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/de/architecture.mdx
+++ b/docs/de/architecture.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/de/ci-cd.mdx
+++ b/docs/de/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/de/content-authors.mdx
+++ b/docs/de/content-authors.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/de/docker.mdx
+++ b/docs/de/docker.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/es/architecture.mdx
+++ b/docs/es/architecture.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/es/ci-cd.mdx
+++ b/docs/es/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/es/content-authors.mdx
+++ b/docs/es/content-authors.mdx
@@ -4,7 +4,7 @@ description: Previsualice su documentación localmente con un solo comando de Do
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/es/docker.mdx
+++ b/docs/es/docker.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/fr/architecture.mdx
+++ b/docs/fr/architecture.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/fr/ci-cd.mdx
+++ b/docs/fr/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/fr/content-authors.mdx
+++ b/docs/fr/content-authors.mdx
@@ -4,7 +4,7 @@ description: Prévisualisez votre documentation localement avec une seule comman
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/fr/docker.mdx
+++ b/docs/fr/docker.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/hi/architecture.mdx
+++ b/docs/hi/architecture.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/hi/ci-cd.mdx
+++ b/docs/hi/ci-cd.mdx
@@ -4,7 +4,7 @@ description: 'GitHub Actions वर्कफ़्लो, टेम्पले�
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/hi/content-authors.mdx
+++ b/docs/hi/content-authors.mdx
@@ -4,7 +4,7 @@ description: एक ही Docker कमांड से अपने डॉक�
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/hi/docker.mdx
+++ b/docs/hi/docker.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/it/architecture.mdx
+++ b/docs/it/architecture.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/it/ci-cd.mdx
+++ b/docs/it/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/it/content-authors.mdx
+++ b/docs/it/content-authors.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/it/docker.mdx
+++ b/docs/it/docker.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/ja/architecture.mdx
+++ b/docs/ja/architecture.mdx
@@ -4,7 +4,7 @@ description: ドキュメントビルダーのシステム設計、ディレク�
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/ja/ci-cd.mdx
+++ b/docs/ja/ci-cd.mdx
@@ -4,7 +4,7 @@ description: GitHub Actions ワークフロー、テンプレート同期、シ�
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/ja/content-authors.mdx
+++ b/docs/ja/content-authors.mdx
@@ -4,7 +4,7 @@ description: 単一のDockerコマンドでドキュメントをローカルプ�
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/ja/docker.mdx
+++ b/docs/ja/docker.mdx
@@ -4,7 +4,7 @@ description: Dockerfile のレイヤー、エントリポイントのオーケ�
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/ko/architecture.mdx
+++ b/docs/ko/architecture.mdx
@@ -4,7 +4,7 @@ description: '문서 빌더의 시스템 설계, 디렉터리 구조, 테마 시
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/ko/ci-cd.mdx
+++ b/docs/ko/ci-cd.mdx
@@ -4,7 +4,7 @@ description: 'GitHub Actions 워크플로우, 템플릿 동기화, 시크릿, �
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/ko/content-authors.mdx
+++ b/docs/ko/content-authors.mdx
@@ -4,7 +4,7 @@ description: 단일 Docker 명령으로 문서를 로컬에서 미리 봅니다.
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/ko/docker.mdx
+++ b/docs/ko/docker.mdx
@@ -4,7 +4,7 @@ description: 'Dockerfile 레이어, 엔트리포인트 오케스트레이션, �
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/pt-br/architecture.mdx
+++ b/docs/pt-br/architecture.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/pt-br/ci-cd.mdx
+++ b/docs/pt-br/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/pt-br/content-authors.mdx
+++ b/docs/pt-br/content-authors.mdx
@@ -4,7 +4,7 @@ description: Pré-visualize sua documentação localmente com um único comando 
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/pt-br/docker.mdx
+++ b/docs/pt-br/docker.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/th/architecture.mdx
+++ b/docs/th/architecture.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/th/ci-cd.mdx
+++ b/docs/th/ci-cd.mdx
@@ -4,7 +4,7 @@ description: 'เวิร์กโฟลว์ GitHub Actions, การซิ�
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/th/content-authors.mdx
+++ b/docs/th/content-authors.mdx
@@ -4,7 +4,7 @@ description: แสดงตัวอย่างเอกสารในเค�
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/th/docker.mdx
+++ b/docs/th/docker.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/zh-cn/architecture.mdx
+++ b/docs/zh-cn/architecture.mdx
@@ -4,7 +4,7 @@ description: 文档构建器的系统设计、目录布局、主题系统和构�
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/zh-cn/ci-cd.mdx
+++ b/docs/zh-cn/ci-cd.mdx
@@ -4,7 +4,7 @@ description: GitHub Actions 工作流、模板同步、密钥和分支保护。
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/zh-cn/content-authors.mdx
+++ b/docs/zh-cn/content-authors.mdx
@@ -4,7 +4,7 @@ description: 使用单条 Docker 命令在本地预览您的文档。
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/zh-cn/docker.mdx
+++ b/docs/zh-cn/docker.mdx
@@ -4,7 +4,7 @@ description: Dockerfile 分层、入口点编排、环境变量及本地使用�
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 

--- a/docs/zh-tw/architecture.mdx
+++ b/docs/zh-tw/architecture.mdx
@@ -4,7 +4,7 @@ description: 文件建構器的系統設計、目錄配置、主題系統與建�
 sidebar:
   order: 5
 i18n:
-  sourceHash: a16b586bcbe1
+  sourceHash: 6d18fbdaa984
   translator: machine
 ---
 

--- a/docs/zh-tw/ci-cd.mdx
+++ b/docs/zh-tw/ci-cd.mdx
@@ -4,7 +4,7 @@ description: GitHub Actions 工作流程、範本同步、密鑰與分支保護�
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3b4552f7ab42
+  sourceHash: 3bb2ff1e0ed2
   translator: machine
 ---
 

--- a/docs/zh-tw/content-authors.mdx
+++ b/docs/zh-tw/content-authors.mdx
@@ -4,7 +4,7 @@ description: 使用單一 Docker 命令在本機預覽您的文件。
 sidebar:
   order: 7
 i18n:
-  sourceHash: d5ec9a607f67
+  sourceHash: cbd94c0e4c07
   translator: machine
 ---
 

--- a/docs/zh-tw/docker.mdx
+++ b/docs/zh-tw/docker.mdx
@@ -4,7 +4,7 @@ description: Dockerfile 層級、入口點協調、環境變數及本地使用�
 sidebar:
   order: 4
 i18n:
-  sourceHash: f8453f94aa45
+  sourceHash: ff60cc21940a
   translator: machine
 ---
 


### PR DESCRIPTION
## Problem

`audit / Translation freshness` fails on 48 machine-translated locale files, blocking governance sync PR #744. Root cause: the org-rename sweep (`f5xc-salesdemos` → `f5-sales-demo`) updated en+locale content but did not restamp `i18n.sourceHash`.

Verified content-current: the only en change since each stored hash is the org rename, already applied in the locale files (guard confirmed org-rename-only for every file; 0 needing re-translation).

## Fix

Restamp `i18n.sourceHash` to `sha256(en)[:12]` in the 48 affected files. One hash line per file; no prose edits.

## Acceptance criteria
- [ ] `audit / Translation freshness` passes.
- [ ] Only `sourceHash` values change.

Unblocks governance sync PR #744.

Closes #745