### PR TITLE
fix: publish favicon.svg so site icon link resolves (#776)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,12 @@ COPY . .
 RUN cp node_modules/@f5-sales-demo/docs-theme/astro.config.mjs /app/astro.config.mjs && \
     cp node_modules/@f5-sales-demo/docs-theme/src/content.config.ts /app/src/content.config.ts
 
+# Provide the default site favicon from the theme's logo. Starlight references
+# /favicon.svg; publicDir assets are served at /<base>/favicon.svg. Without this
+# every site's <link rel="icon" href="/<base>/favicon.svg"> 404s.
+RUN mkdir -p /app/public && \
+    cp node_modules/@f5-sales-demo/docs-theme/assets/f5-logo.svg /app/public/favicon.svg
+
 # Remove placeholder content
 RUN rm -rf src/content/docs/*
 


### PR DESCRIPTION
## Summary

Every site's `<link rel="icon" href="/<base>/favicon.svg">` 404'd because the build published no favicon. Copy the theme's `assets/f5-logo.svg` to `/app/public/favicon.svg` in the image build so Astro serves it at `/<base>/favicon.svg` on every downstream site. Reuses the theme's existing logo (no new asset, no content-repo change).

## Verification

- Confirmed `@f5-sales-demo/docs-theme` publishes `assets/f5-logo.svg`, so the copy resolves in the image.
- Image build CI exercises the copy step.
- Post-merge: after the image publishes and a site rebuilds, `/<base>/favicon.svg` returns 200 (was 404).

Fixes #776