### PR TITLE
fix: link ci-cd CONTRIBUTING reference to GitHub (#780)

### DIFF
--- a/docs/ar/ci-cd.mdx
+++ b/docs/ar/ci-cd.mdx
@@ -4,7 +4,7 @@ description: سير عمل GitHub Actions، مزامنة القوالب، الأ
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -84,7 +84,7 @@ on:
 exclude-branches: "dependabot/**"
 ```
 
-تُعرض رسالة مخصصة تُخبر المساهمين بالصيغة المتوقعة إذا فشل الفحص. انظر [CONTRIBUTING.md](../CONTRIBUTING.md) لسير عمل المساهمين الكامل.
+تُعرض رسالة مخصصة تُخبر المساهمين بالصيغة المتوقعة إذا فشل الفحص. انظر [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) لسير عمل المساهمين الكامل.
 
 ### فرض إعدادات المستودع
 

--- a/docs/de/ci-cd.mdx
+++ b/docs/de/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -86,7 +86,7 @@ Verwendet `nearform-actions/github-action-check-linked-issues@v1`, um sicherzust
 exclude-branches: "dependabot/**"
 ```
 
-Eine benutzerdefinierte Nachricht informiert Mitwirkende über das erwartete Format, wenn die Prüfung fehlschlägt. Siehe [CONTRIBUTING.md](../CONTRIBUTING.md) für den vollständigen Contributor-Workflow.
+Eine benutzerdefinierte Nachricht informiert Mitwirkende über das erwartete Format, wenn die Prüfung fehlschlägt. Siehe [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) für den vollständigen Contributor-Workflow.
 
 ### Enforce Repository Settings
 

--- a/docs/en/ci-cd.mdx
+++ b/docs/en/ci-cd.mdx
@@ -81,7 +81,7 @@ Uses `nearform-actions/github-action-check-linked-issues@v1` to enforce that eve
 exclude-branches: "dependabot/**"
 ```
 
-A custom message tells contributors the expected format if the check fails. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow.
+A custom message tells contributors the expected format if the check fails. See [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) for the full contributor workflow.
 
 ### Enforce Repository Settings
 

--- a/docs/es/ci-cd.mdx
+++ b/docs/es/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -86,7 +86,7 @@ Utiliza `nearform-actions/github-action-check-linked-issues@v1` para exigir que 
 exclude-branches: "dependabot/**"
 ```
 
-Un mensaje personalizado indica a los colaboradores el formato esperado si la verificación falla. Consulte [CONTRIBUTING.md](../CONTRIBUTING.md) para el flujo de trabajo completo del colaborador.
+Un mensaje personalizado indica a los colaboradores el formato esperado si la verificación falla. Consulte [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) para el flujo de trabajo completo del colaborador.
 
 ### Enforce Repository Settings
 

--- a/docs/fr/ci-cd.mdx
+++ b/docs/fr/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -86,7 +86,7 @@ Utilise `nearform-actions/github-action-check-linked-issues@v1` pour imposer que
 exclude-branches: "dependabot/**"
 ```
 
-Un message personnalisé indique aux contributeurs le format attendu si la vérification échoue. Consultez [CONTRIBUTING.md](../CONTRIBUTING.md) pour le workflow complet du contributeur.
+Un message personnalisé indique aux contributeurs le format attendu si la vérification échoue. Consultez [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) pour le workflow complet du contributeur.
 
 ### Enforce Repository Settings
 

--- a/docs/hi/ci-cd.mdx
+++ b/docs/hi/ci-cd.mdx
@@ -4,7 +4,7 @@ description: 'GitHub Actions वर्कफ़्लो, टेम्पले�
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -84,7 +84,7 @@ on:
 exclude-branches: "dependabot/**"
 ```
 
-यदि चेक विफल होता है तो एक कस्टम संदेश योगदानकर्ताओं को अपेक्षित प्रारूप बताता है। पूर्ण योगदानकर्ता वर्कफ़्लो के लिए [CONTRIBUTING.md](../CONTRIBUTING.md) देखें।
+यदि चेक विफल होता है तो एक कस्टम संदेश योगदानकर्ताओं को अपेक्षित प्रारूप बताता है। पूर्ण योगदानकर्ता वर्कफ़्लो के लिए [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) देखें।
 
 ### Enforce Repository Settings
 

--- a/docs/it/ci-cd.mdx
+++ b/docs/it/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -86,7 +86,7 @@ Utilizza `nearform-actions/github-action-check-linked-issues@v1` per imporre che
 exclude-branches: "dependabot/**"
 ```
 
-Un messaggio personalizzato informa i contributori del formato atteso nel caso in cui il controllo fallisca. Consultare [CONTRIBUTING.md](../CONTRIBUTING.md) per il flusso di lavoro completo dei contributori.
+Un messaggio personalizzato informa i contributori del formato atteso nel caso in cui il controllo fallisca. Consultare [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) per il flusso di lavoro completo dei contributori.
 
 ### Enforce Repository Settings
 

--- a/docs/ja/ci-cd.mdx
+++ b/docs/ja/ci-cd.mdx
@@ -4,7 +4,7 @@ description: GitHub Actions ワークフロー、テンプレート同期、シ�
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -84,7 +84,7 @@ on:
 exclude-branches: "dependabot/**"
 ```
 
-チェックに失敗した場合、コントリビューターに期待されるフォーマットを示すカスタムメッセージが表示されます。コントリビューターワークフローの詳細については [CONTRIBUTING.md](../CONTRIBUTING.md) を参照してください。
+チェックに失敗した場合、コントリビューターに期待されるフォーマットを示すカスタムメッセージが表示されます。コントリビューターワークフローの詳細については [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) を参照してください。
 
 ### リポジトリ設定の適用
 

--- a/docs/ko/ci-cd.mdx
+++ b/docs/ko/ci-cd.mdx
@@ -4,7 +4,7 @@ description: 'GitHub Actions 워크플로우, 템플릿 동기화, 시크릿, �
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -84,7 +84,7 @@ on:
 exclude-branches: "dependabot/**"
 ```
 
-검사가 실패하면 기여자에게 예상되는 형식을 알려주는 사용자 정의 메시지가 표시됩니다. 전체 기여자 워크플로우는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 참조하세요.
+검사가 실패하면 기여자에게 예상되는 형식을 알려주는 사용자 정의 메시지가 표시됩니다. 전체 기여자 워크플로우는 [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md)를 참조하세요.
 
 ### 저장소 설정 적용
 

--- a/docs/pt-br/ci-cd.mdx
+++ b/docs/pt-br/ci-cd.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -86,7 +86,7 @@ Utiliza `nearform-actions/github-action-check-linked-issues@v1` para garantir qu
 exclude-branches: "dependabot/**"
 ```
 
-Uma mensagem personalizada informa aos contribuidores o formato esperado caso a verificação falhe. Consulte [CONTRIBUTING.md](../CONTRIBUTING.md) para o fluxo completo de contribuição.
+Uma mensagem personalizada informa aos contribuidores o formato esperado caso a verificação falhe. Consulte [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) para o fluxo completo de contribuição.
 
 ### Enforce Repository Settings
 

--- a/docs/th/ci-cd.mdx
+++ b/docs/th/ci-cd.mdx
@@ -4,7 +4,7 @@ description: 'เวิร์กโฟลว์ GitHub Actions, การซิ�
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -84,7 +84,7 @@ on:
 exclude-branches: "dependabot/**"
 ```
 
-ข้อความกำหนดเองจะแจ้งผู้มีส่วนร่วมเกี่ยวกับรูปแบบที่คาดหวังหากการตรวจสอบล้มเหลว ดู [CONTRIBUTING.md](../CONTRIBUTING.md) สำหรับขั้นตอนการทำงานของผู้มีส่วนร่วมฉบับสมบูรณ์
+ข้อความกำหนดเองจะแจ้งผู้มีส่วนร่วมเกี่ยวกับรูปแบบที่คาดหวังหากการตรวจสอบล้มเหลว ดู [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) สำหรับขั้นตอนการทำงานของผู้มีส่วนร่วมฉบับสมบูรณ์
 
 ### Enforce Repository Settings
 

--- a/docs/zh-cn/ci-cd.mdx
+++ b/docs/zh-cn/ci-cd.mdx
@@ -4,7 +4,7 @@ description: GitHub Actions 工作流、模板同步、密钥和分支保护。
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -84,7 +84,7 @@ on:
 exclude-branches: "dependabot/**"
 ```
 
-检查失败时会显示自定义消息，告知贡献者预期的格式。完整的贡献者工作流请参阅 [CONTRIBUTING.md](../CONTRIBUTING.md)。
+检查失败时会显示自定义消息，告知贡献者预期的格式。完整的贡献者工作流请参阅 [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md)。
 
 ### 强制执行仓库设置
 

--- a/docs/zh-tw/ci-cd.mdx
+++ b/docs/zh-tw/ci-cd.mdx
@@ -4,7 +4,7 @@ description: GitHub Actions 工作流程、範本同步、密鑰與分支保護�
 sidebar:
   order: 6
 i18n:
-  sourceHash: 3bb2ff1e0ed2
+  sourceHash: 1719e9cd3e1c
   translator: machine
 ---
 
@@ -84,7 +84,7 @@ on:
 exclude-branches: "dependabot/**"
 ```
 
-如果檢查失敗，會顯示自訂訊息告知貢獻者預期的格式。請參閱 [CONTRIBUTING.md](../CONTRIBUTING.md) 了解完整的貢獻者工作流程。
+如果檢查失敗，會顯示自訂訊息告知貢獻者預期的格式。請參閱 [CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-builder/blob/main/CONTRIBUTING.md) 了解完整的貢獻者工作流程。
 
 ### 強制執行儲存庫設定
 


### PR DESCRIPTION
## Summary
`[CONTRIBUTING.md](../CONTRIBUTING.md)` on the ci-cd page 404'd (CONTRIBUTING isn't a published doc page; it's at the repo root). Pointed it at the GitHub blob URL across all 13 locales.

## Verification
- Residual `](../CONTRIBUTING.md)` → **0**.
- Local translation-freshness audit → fresh.

Fixes #780