### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -26,6 +26,7 @@
     ".github/workflows/dependabot-auto-merge.yml",
     ".github/workflows/auto-merge.yml",
     ".github/workflows/code-review.yml",
+    ".github/workflows/semgrep.yml",
     ".github/workflows/translation-audit.yml",
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/ISSUE_TEMPLATE/bug_report.md",


### PR DESCRIPTION
Closes #824

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/require-linked-issue.yml
- .github/workflows/super-linter.yml
- .github/workflows/dependabot-auto-merge.yml
- .github/workflows/auto-merge.yml
- .claude/governance.json