### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]'
-    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@4796ba660860c59b27aedd52fb30ed1841897a16
+    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@1fdac0c56a9fe211da5b858e480cb1ee854bbdd3
     permissions:
       contents: write # fallback GITHUB_TOKEN must be able to complete the merge
       pull-requests: write # enable auto-merge and update the pull request

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -70,7 +70,7 @@ jobs:
         startsWith(github.head_ref, 'auto-generate/') ||
         startsWith(github.head_ref, 'autoresearch/') ||
         (startsWith(github.head_ref, 'dependabot/') && github.actor == 'dependabot[bot]'))
-    uses: f5-sales-demo/docs-control/.github/workflows/claude-review.yml@4796ba660860c59b27aedd52fb30ed1841897a16
+    uses: f5-sales-demo/docs-control/.github/workflows/claude-review.yml@1fdac0c56a9fe211da5b858e480cb1ee854bbdd3
     permissions:
       contents: read # inspect the same-repository pull request
       pull-requests: write # publish the reusable review result

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@4796ba660860c59b27aedd52fb30ed1841897a16
+    uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@1fdac0c56a9fe211da5b858e480cb1ee854bbdd3
     permissions:
       contents: write # merge the validated Dependabot update
       pull-requests: write # approve and enable auto-merge

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -25,14 +25,14 @@ concurrency:
 
 jobs:
   enforce-settings:
-    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@4796ba660860c59b27aedd52fb30ed1841897a16
+    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@1fdac0c56a9fe211da5b858e480cb1ee854bbdd3
     with:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
   sync-files:
-    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@4796ba660860c59b27aedd52fb30ed1841897a16
+    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@1fdac0c56a9fe211da5b858e480cb1ee854bbdd3
     with:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@4796ba660860c59b27aedd52fb30ed1841897a16
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@1fdac0c56a9fe211da5b858e480cb1ee854bbdd3
     permissions:
       contents: read # read documentation sources
       packages: read # pull the fleet documentation builder image

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -20,7 +20,7 @@ jobs:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN (always available to a called workflow), so passing repository
     # secrets would hand over more than it needs.
-    uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@4796ba660860c59b27aedd52fb30ed1841897a16
+    uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@1fdac0c56a9fe211da5b858e480cb1ee854bbdd3
     permissions:
       issues: read # verify that the referenced tracking issue exists
       pull-requests: write # publish the required check result and comment

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@4796ba660860c59b27aedd52fb30ed1841897a16
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@1fdac0c56a9fe211da5b858e480cb1ee854bbdd3
     permissions:
       contents: read # checkout repository content in the reusable workflow
       packages: read # pull lint tooling from GitHub Packages

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -35,4 +35,4 @@ jobs:
     # in a job-level `if:`. An unset variable evaluates false, so this fails safe
     # toward not spending money.
     if: vars.TRANSLATIONS_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@4796ba660860c59b27aedd52fb30ed1841897a16
+    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@1fdac0c56a9fe211da5b858e480cb1ee854bbdd3

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -1800,10 +1800,9 @@ def scan_text(path: str, text: str, findings: set[Finding]) -> None:
         if opening_fence and fence:
             fence_marker = fence.group("marker")
             fence_language = parse_fence_language(fence.group("info"))
-            if fence.group("container"):
-                fence_close_column = fence.start("marker") + 3
-            else:
-                fence_close_column = 3
+            fence_container = fence.group("container")
+            container_close_column = fence.start("marker") + 3
+            fence_close_column = container_close_column if fence_container else 3
             active_jq_quote = None
 
         fence_boundary = closing_fence or opening_fence


### PR DESCRIPTION
Closes #910

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/github-pages-deploy.yml
- .github/workflows/enforce-repo-settings.yml
- .github/workflows/require-linked-issue.yml
- .github/workflows/super-linter.yml
- .github/workflows/translation-audit.yml
- .github/workflows/dependabot-auto-merge.yml
- .github/workflows/auto-merge.yml
- scripts/check_pii.py
- .github/workflows/code-review.yml