### PR TITLE
docs: resolve Markdown lint violations

### DIFF
--- a/docs/en/architecture.mdx
+++ b/docs/en/architecture.mdx
@@ -13,7 +13,7 @@ The docs builder is a containerized [Astro](https://astro.build/) + [Starlight](
 
 Content repos keep their documentation in a `docs/` directory. At build time the container copies those files into `src/content/docs/`, where Astro's content collection picks them up.
 
-```
+```text
 content-repo/
   docs/           ← authored by content teams
     index.mdx
@@ -49,7 +49,7 @@ This keeps configuration centralized — content repos and the builder itself do
 
 ## Source Directory Layout
 
-```
+```text
 src/
   components/
     PlaceholderForm.tsx          # React form for editing placeholder values
@@ -100,7 +100,7 @@ flowchart LR
 ## Build-Time vs Client-Time Processing
 
 | Concern | When | How |
-|---------|------|-----|
+| --- | --- | --- |
 | MDX → HTML | Build time | Astro compiler |
 | Mermaid code blocks → container divs | Build time | `remark-mermaid.mjs` plugin (from `docs-theme`) |
 | Placeholder tokens → interactive spans | Client time | `placeholder-dom.ts` TreeWalker |

--- a/docs/en/ci-cd.mdx
+++ b/docs/en/ci-cd.mdx
@@ -10,7 +10,7 @@ The repository uses four GitHub Actions workflows and a centralized template sys
 ## Workflows
 
 | Workflow | File | Trigger | Purpose |
-|----------|------|---------|---------|
+| --- | --- | --- | --- |
 | GitHub Pages Deploy | `github-pages-deploy.yml` | Push to `main` (`docs/**`), manual dispatch | Builds and deploys the documentation site to GitHub Pages |
 | Build and Publish Docker Image | `build-image.yml` | Push to `main` (`docker/**`, `package*.json`), daily cron, `repository_dispatch` | Builds the Docker image, pushes to GHCR, and dispatches rebuilds to downstream repos |
 | Require Linked Issue | `require-linked-issue.yml` | Pull request events | Blocks PRs that do not reference a GitHub issue |
@@ -56,6 +56,7 @@ on:
 ```
 
 Steps:
+
 1. Checkout code
 2. Log in to `ghcr.io` using `docker/login-action`
 3. Build and push using `docker/build-push-action` with context `.` and file `docker/Dockerfile`
@@ -136,6 +137,6 @@ The enforce-repo-settings workflow applies branch protection rules from the temp
 ## Secrets
 
 | Secret | Source | Purpose |
-|--------|--------|---------|
+| --- | --- | --- |
 | `GITHUB_TOKEN` | Automatic (GitHub) | Used by most workflows for checkout, package publishing, and API calls |
 | `REPO_ADMIN_TOKEN` | Manual (repository secret) | Required by enforce-repo-settings and the dispatch job to modify branch protection, repo settings, and trigger downstream workflows (needs admin scope) |

--- a/docs/en/content-authors.mdx
+++ b/docs/en/content-authors.mdx
@@ -24,7 +24,7 @@ docker run --rm -it \
   ghcr.io/f5-sales-demo/docs-builder:latest
 ```
 
-Open **http://localhost:4321** once the server starts.
+Open **[http://localhost:4321](http://localhost:4321)** once the server starts.
 
 :::note
 File changes on your host require restarting the container. Stop it with `Ctrl+C` and re-run the command to pick up edits.

--- a/docs/en/docker.mdx
+++ b/docs/en/docker.mdx
@@ -34,7 +34,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 ### Layer Strategy
 
 | Layer | What | Why cached separately |
-|-------|------|----------------------|
+| --- | --- | --- |
 | 1 | `COPY package*.json` + `npm ci` | Dependencies change infrequently; caching this layer avoids re-downloading on every build |
 | 2 | `COPY . .` | Framework source code |
 | 3 | `rm -rf src/content/docs/*` | Cleans out any placeholder content so only injected content appears |
@@ -118,7 +118,7 @@ Copies the built site to the output mount point.
 ## Environment Variables
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| --- | --- | --- |
 | `CONTENT_DIR` | `/content/docs` | Path to the mounted content directory |
 | `OUTPUT_DIR` | `/output` | Path where the built site is copied |
 | `DOCS_TITLE` | *(extracted from index.mdx)* | Site title passed to the Astro config |
@@ -172,14 +172,14 @@ Open `http://localhost:4321`. Hot module replacement (HMR) works for component a
 
 The image is published to GitHub Container Registry:
 
-```
+```text
 ghcr.io/f5-sales-demo/docs-builder
 ```
 
 Two tags are pushed on every build:
 
 | Tag | Description |
-|-----|-------------|
+| --- | --- |
 | `latest` | Most recent build from `main` |
 | `<sha>` | Full Git commit SHA for reproducible builds |
 

--- a/docs/en/mermaid.mdx
+++ b/docs/en/mermaid.mdx
@@ -33,7 +33,7 @@ visit(tree, 'code', (node, index, parent) => {
 Key details:
 
 | Aspect | Value |
-|--------|-------|
+| --- | --- |
 | Node type matched | `code` nodes where `lang === 'mermaid'` |
 | HTML entity escaping | `&`, `<`, `>`, `"` — prevents attribute injection in `data-mermaid-src` |
 | Output structure | `<div class="mermaid-container">` with `data-mermaid-src` attribute holding the escaped source |
@@ -109,7 +109,7 @@ This makes authoring errors visible without breaking the rest of the page.
 Diagrams re-render in two situations:
 
 | Trigger | Event | What happens |
-|---------|-------|-------------|
+| --- | --- | --- |
 | Placeholder value changes | `placeholder-change` | `handleChange()` calls `renderMermaidDiagrams()` with new values |
 | Astro page navigation | `astro:page-load` | `init()` calls `renderMermaidDiagrams()` for the new page |
 

--- a/docs/en/placeholder-system.mdx
+++ b/docs/en/placeholder-system.mdx
@@ -11,7 +11,7 @@ The placeholder system lets readers customize IP addresses, ASNs, and other depl
 
 Tokens follow the regex pattern:
 
-```
+```text
 x([A-Z][A-Z0-9_]+)x
 ```
 
@@ -38,7 +38,7 @@ All placeholders are declared in `src/data/placeholders.json`. Each entry has th
 ```
 
 | Field | Required | Description |
-|-------|----------|-------------|
+| --- | --- | --- |
 | `type` | yes | `"text"` for free-form input, `"dropdown"` for select menus |
 | `default` | yes | Initial value shown before the reader changes anything |
 | `description` | yes | Label displayed in the form |
@@ -53,7 +53,7 @@ All placeholders are declared in `src/data/placeholders.json`. Each entry has th
 Values are persisted in `localStorage` under the key `f5xc-placeholders`. The store exposes four functions:
 
 | Function | Purpose |
-|----------|---------|
+| --- | --- |
 | `getDefaults()` | Returns a map of every placeholder key to its `default` value from JSON |
 | `loadValues()` | Reads from localStorage, falls back to `getDefaults()` |
 | `saveValues(values)` | Writes the current map to localStorage |
@@ -87,7 +87,7 @@ const cidrToMask: Record<string, string> = {
 Two computed placeholders are produced:
 
 | Computed Key | Derived From | Example |
-|-------------|-------------|---------|
+| --- | --- | --- |
 | `PROTECTED_MASK_V4` | `PROTECTED_CIDR_V4` via `cidrToMask` lookup | `255.255.255.0` |
 | `PROTECTED_PREFIX_V4` | `PROTECTED_NET_V4` + `PROTECTED_CIDR_V4` via `cidrToShort` | `192.0.2.0/24` |
 
@@ -169,13 +169,14 @@ This avoids re-walking the tree — it directly updates the span text content.
 The script registers two listeners:
 
 | Event | Handler | Purpose |
-|-------|---------|---------|
+| --- | --- | --- |
 | `placeholder-change` | `handleChange` | Updates spans and re-renders Mermaid diagrams |
 | `astro:page-load` | `init` | Re-walks the DOM after Astro client-side navigation |
 
 ## How To: Add a New Placeholder
 
 1. **Add the JSON entry** in `src/data/placeholders.json`:
+
    ```json
    "MY_NEW_VALUE": {
      "type": "text",
@@ -195,6 +196,7 @@ Computed values are derived from other placeholders. To add one:
 1. Add a lookup table (if needed) in `src/lib/placeholder-store.ts`, following the pattern of `cidrToMask`.
 
 2. Extend `getComputedValues()` to include the new derived key:
+
    ```ts
    export function getComputedValues(values: Record<string, string>): Record<string, string> {
      // ... existing logic


### PR DESCRIPTION
## Summary

- normalize Markdown tables and structural formatting for the newly enforced fleet rules
- tag schematic and command fences where the same touched files exposed untagged blocks
- keep translated content untouched for its planned final regeneration

Closes #914

## Testing

- markdownlint-cli 0.49.1 and governed prose gate on every changed Markdown/MDX file
- shellcheck and shfmt over every tracked shell script
- `npm run build`
- `git diff --check origin/main...HEAD`
