### PR TITLE
fix: refresh audited production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6285,9 +6285,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7334,9 +7334,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Refreshes the two vulnerable production transitive lockfile entries that blocked the docs-theme v3.10.0 image rebuild and downstream Pages redispatch.

## Related Issue

Closes #974

## Changes

- update `brace-expansion` from 5.0.8 to 5.0.9
- update `fast-uri` from 3.1.4 to 3.1.5
- preserve all direct dependency ranges and the production audit gate

## Verification evidence

- `npm ci --ignore-scripts` — 804 packages audited, zero vulnerabilities
- `npm audit --omit=dev --audit-level=high` — zero vulnerabilities
- `npm ls brace-expansion fast-uri --all` — resolves 5.0.9 and 3.1.5
- `pre-commit run --files package-lock.json` — passed
- `npm run build` — passed
- staged and HEAD PII enforcement — clean
- `bash scripts/agy-pre-push-review.sh` — passed with no high or critical findings

## Checklist

- [x] Linked to a GitHub issue
- [x] Feature-complete and verified
- [x] Verified locally with clean install, audit, hooks, and build
- [ ] CI watched to green
- [x] Follows project conventions
